### PR TITLE
Set proper Docker container image tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: build(ci)

--- a/.github/workflows/imswitch-docker-multiarch-noqt.yaml
+++ b/.github/workflows/imswitch-docker-multiarch-noqt.yaml
@@ -9,104 +9,148 @@ permissions:
   packages: write
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: openuc2/imswitch-noqt
-  CACHE_NAME: openuc2/imswitch-noqt-cache
+  REGISTRY: ghcr.io/${{ github.repository_owner }}
+  IMAGE_NAME: imswitch-noqt
+  CACHE_NAME: imswitch-noqt-cache
+  PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
 
 jobs:
-  build-arm64:
-    runs-on: ubuntu-22.04-arm
+  build-container-image:
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker-platform: linux/amd64
+            gha-runner: ubuntu-latest
+          - docker-platform: linux/arm64
+            gha-runner: ubuntu-latest-arm
+    runs-on: ${{ matrix.gha-runner }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
+      # Work around a bug where capital letters in the GitHub username (e.g. "PlanktoScope") make it
+      # impossible to push to GHCR. See https://github.com/macbre/push-to-ghcr/issues/12
+      - name: Lowercase image registry and owner
+        id: image_registry_case
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and publish Docker container image
+      - name: Get Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image_registry_case.outputs.lowercase }}
+          tags: |
+            type=sha # this sha doesn't appear to correspond to the git sha
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
           driver: docker-container  # Ensures proper driver setup
 
       - name: Log in to GitHub container registry
-        uses: docker/login-action@v2
+        if: env.PUSH_IMAGE == 'true'
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push ARM64 image
-        uses: docker/build-push-action@v4
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: dockerfile
-          platforms: linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arm64:latest
-          cache-to: type=registry,mode=max,ref=${{ env.REGISTRY }}/${{ env.CACHE_NAME }}-arm64:cache
-          cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.CACHE_NAME }}-arm64:cache
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arm64:latest
+          pull: true
+          platforms: ${{ matrix.docker-platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=build-${{ matrix.docker-platform }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.docker-platform }}
+          outputs: type=image,name=${{ steps.image_registry_case.outputs.lowercase }},push-by-digest=true,name-canonical=true,push=${{ env.PUSH_IMAGE }}
           build-args: |
             BUILD_DATE=${{ github.run_id }}
 
-  build-amd64:
+  merge-container-images:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
+    needs:
+      - build-container-image
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 2
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      # Work around a bug where capital letters in the GitHub username (e.g. "PlanktoScope") make it
+      # impossible to push to GHCR. See https://github.com/macbre/push-to-ghcr/issues/12
+      - name: Lowercase image registry and owner
+        id: image_registry_case
+        uses: ASzc/change-string-case-action@v6
         with:
-          install: true
-          driver: docker-container  # Ensures proper driver setup
+          string: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Log in to GitHub container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get actual commit SHA
+        # Get the SHA of the actual commit (not the fake merge commit) on PR-triggered runs
+        # (refer to https://stackoverflow.com/a/68068674/23202949):
+        run: |
+          if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
+            printf "ACTUAL_SHA=%.7s" "${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          elif [[ ${{ env.PUSH_IMAGE }} = "true" ]]; then
+            printf "ACTUAL_SHA=%.7s" "${{ github.sha }}" >> $GITHUB_ENV
+          fi
 
-      - name: Build and push AMD64 image
-        uses: docker/build-push-action@v4
+      # Build and publish Docker container image
+      - name: Get Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          IS_MAIN_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}
+          IS_BETA_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.BETA_BRANCH) }}
+          IS_STABLE_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.STABLE_BRANCH) }}
         with:
-          context: .
-          file: dockerfile
-          platforms: linux/amd64
-          push: true
+          images: ${{ steps.image_registry_case.outputs.lowercase }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-amd64:latest
-          cache-to: type=registry,mode=max,ref=${{ env.REGISTRY }}/${{ env.CACHE_NAME }}-amd64:cache
-          cache-from: |
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.CACHE_NAME }}-amd64:cache
-            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-amd64:latest
-          build-args: |
-            BUILD_DATE=${{ github.run_id }}
+            type=match,pattern=${{ env.TAG_PREFIX }}(.*),group=1 # this implicitly updates latest
+            type=raw,value=stable,enable=${{ env.IS_STABLE_BRANCH }},priority=702
+            type=raw,value=beta,enable=${{ env.IS_BETA_BRANCH }},priority=701
+            type=edge,branch=${{ env.MAIN_BRANCH }}
+            type=ref,event=pr
+            type=raw,value=sha-${{ env.ACTUAL_SHA }},enable=${{ env.ACTUAL_SHA != '' }},priority=100
 
-  create-manifest:
-    needs: [build-amd64, build-arm64]
-    runs-on: ubuntu-latest
-    steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          install: true
+        uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub container registry
-        uses: docker/login-action@v2
+      - name: Log in to GitHub Container Registry
+        if: env.PUSH_IMAGE == 'true'
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push multi-arch manifest
+      - name: Create manifest list and push
+        if: env.PUSH_IMAGE == 'true'
+        working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            --tag $REGISTRY/$IMAGE_NAME:latest \
-            $REGISTRY/$IMAGE_NAME-amd64:latest \
-            $REGISTRY/$IMAGE_NAME-arm64:latest
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ steps.image_registry_case.outputs.lowercase }}@sha256:%s ' *)
+
+      - name: Inspect image
+        if: env.PUSH_IMAGE == 'true'
+        run: |
+          docker buildx imagetools inspect \
+            ${{ steps.image_registry_case.outputs.lowercase }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/imswitch-docker-multiarch-noqt.yaml
+++ b/.github/workflows/imswitch-docker-multiarch-noqt.yaml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 env:
-  REGISTRY: ghcr.io/${{ github.repository_owner }}
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   IMAGE_NAME: imswitch-noqt
   CACHE_NAME: imswitch-noqt-cache
   PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
@@ -24,9 +24,9 @@ jobs:
       matrix:
         include:
           - docker-platform: linux/amd64
-            gha-runner: ubuntu-latest
+            gha-runner: ubuntu-24.04
           - docker-platform: linux/arm64
-            gha-runner: ubuntu-latest-arm
+            gha-runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.gha-runner }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -22,7 +22,12 @@ env:
   IMAGE_NAME: imswitch-noqt
   MAIN_BRANCH: 'master' # pushing to this branch will update the "edge" tag on the image
   TAG_PREFIX: 'v' # pushing tags with this prefix will add a version tag to the image and update the "latest" tag on the image
-  PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
+  # Because openUC2/ImSwitch is a fork of an upstream repo, we can't suppress attempts to push
+  # container images for forks of the openUC2/ImSwitch repo. That's is probably acceptable for how
+  # we develop this project (i.e. with PRs from branches on the openUC2/ImSwitch repo, rather than
+  # PRs from user-created forks of openUC2/ImSwitch).
+  # PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
+  PUSH_IMAGE: ${{ (github.event_name == 'pull_request') || github.event_name == 'push' || github.event_name == 'push tag' }}
 
 jobs:
   build-container-image:

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -2,6 +2,9 @@ name: imswitch-docker-noqt
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'main'
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -1,4 +1,4 @@
-name: imswitch-docker-multiarch-noqt
+name: imswitch-docker-noqt
 
 on:
   push:
@@ -78,6 +78,25 @@ jobs:
           outputs: type=image,name=${{ steps.image_registry_case.outputs.lowercase }},push-by-digest=true,name-canonical=true,push=${{ env.PUSH_IMAGE }}
           build-args: |
             BUILD_DATE=${{ github.run_id }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Determine digest name
+        run: |
+          platform=${{ matrix.docker-platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
   merge-container-images:
     permissions:

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -27,7 +27,7 @@ env:
   # we develop this project (i.e. with PRs from branches on the openUC2/ImSwitch repo, rather than
   # PRs from user-created forks of openUC2/ImSwitch).
   # PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
-  PUSH_IMAGE: ${{ (github.event_name == 'pull_request') || github.event_name == 'push' || github.event_name == 'push tag' }}
+  PUSH_IMAGE: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'push tag' }}
 
 jobs:
   build-container-image:

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -19,12 +19,7 @@ env:
   IMAGE_NAME: imswitch-noqt
   MAIN_BRANCH: 'master' # pushing to this branch will update the "edge" tag on the image
   TAG_PREFIX: 'v' # pushing tags with this prefix will add a version tag to the image and update the "latest" tag on the image
-  # Because openUC2/ImSwitch is a fork of an upstream repo, we can't suppress attempts to push
-  # container images for forks of the openUC2/ImSwitch repo. That's is probably acceptable for how
-  # we develop this project (i.e. with PRs from branches on the openUC2/ImSwitch repo, rather than
-  # PRs from user-created forks of openUC2/ImSwitch).
-  # PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
-  PUSH_IMAGE: ${{ (github.event_name == 'pull_request') || github.event_name == 'push' || github.event_name == 'push tag' }}
+  PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
 
 jobs:
   build-container-image:

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -12,6 +12,7 @@ env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   IMAGE_NAME: imswitch-noqt
   MAIN_BRANCH: 'master' # pushing to this branch will update the "edge" tag on the image
+  TAG_PREFIX: 'v' # pushing tags with this prefix will add a version tag to the image and update the "latest" tag on the image
   # Because openUC2/ImSwitch is a fork of an upstream repo, we can't suppress attempts to push
   # container images for forks of the openUC2/ImSwitch repo. That's is probably acceptable for how
   # we develop this project (i.e. with PRs from branches on the openUC2/ImSwitch repo, rather than
@@ -126,21 +127,12 @@ jobs:
         with:
           string: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Get actual commit SHA
-        # Get the SHA of the actual commit (not the fake merge commit) on PR-triggered runs
-        # (refer to https://stackoverflow.com/a/68068674/23202949):
-        run: |
-          if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
-            printf "ACTUAL_SHA=%.7s" "${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-          elif [[ ${{ env.PUSH_IMAGE }} = "true" ]]; then
-            printf "ACTUAL_SHA=%.7s" "${{ github.sha }}" >> $GITHUB_ENV
-          fi
-
       # Build and publish Docker container image
       - name: Get Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         env:
+          DOCKERMETADATA_PR_HEAD_SHA: true
           IS_MAIN_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}
           IS_BETA_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.BETA_BRANCH) }}
           IS_STABLE_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.STABLE_BRANCH) }}
@@ -152,7 +144,7 @@ jobs:
             type=raw,value=beta,enable=${{ env.IS_BETA_BRANCH }},priority=701
             type=edge,branch=${{ env.MAIN_BRANCH }}
             type=ref,event=pr
-            type=raw,value=sha-${{ env.ACTUAL_SHA }},enable=${{ env.ACTUAL_SHA != '' }},priority=100
+            type=sha,priority=100
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -2,7 +2,13 @@ name: imswitch-docker-noqt
 
 on:
   push:
+  pull_request:
+  merge_group:
   workflow_dispatch:
+    inputs:
+      git-ref:
+        description: 'Git ref (optional)'
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -133,7 +133,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         env:
-          DOCKERMETADATA_PR_HEAD_SHA: true
+          DOCKER_METADATA_PR_HEAD_SHA: true
           IS_MAIN_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}
           IS_BETA_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.BETA_BRANCH) }}
           IS_STABLE_BRANCH: ${{ github.ref == format('refs/heads/{0}', env.STABLE_BRANCH) }}

--- a/.github/workflows/imswitch-docker-noqt.yaml
+++ b/.github/workflows/imswitch-docker-noqt.yaml
@@ -11,8 +11,13 @@ permissions:
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   IMAGE_NAME: imswitch-noqt
-  CACHE_NAME: imswitch-noqt-cache
-  PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
+  MAIN_BRANCH: 'master' # pushing to this branch will update the "edge" tag on the image
+  # Because openUC2/ImSwitch is a fork of an upstream repo, we can't suppress attempts to push
+  # container images for forks of the openUC2/ImSwitch repo. That's is probably acceptable for how
+  # we develop this project (i.e. with PRs from branches on the openUC2/ImSwitch repo, rather than
+  # PRs from user-created forks of openUC2/ImSwitch).
+  # PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
+  PUSH_IMAGE: ${{ (github.event_name == 'pull_request') || github.event_name == 'push' || github.event_name == 'push tag' }}
 
 jobs:
   build-container-image:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
-  imswitch-docker-arm64-noqt:
-    image: ghcr.io/openuc2/imswitch-noqt-arm64:latest
+  imswitch-docker-noqt:
+    image: ghcr.io/openuc2/imswitch-noqt:latest
     privileged: true
     ports:
       - "3000:3000"


### PR DESCRIPTION
Previously, Docker container images were only published with a `latest` tag, so that [openUC2/pallet](https://github.com/openuc2/pallet) did not have a reproducible version of the ImSwitch Docker container image. As a result, while trying to test https://github.com/openUC2/pallet/pull/18, I was temporarily blocked from testing it due to unrelated regressions in ImSwitch, which was pretty annoying to me. We should have the pallet use a reproducible image tag (e.g. corresponding to a PR or a commit SHA) to prevent this from happening in the future. This PR implements that.

Additionally, previously openUC2/pallet used an arm64-specific container image for ImSwitch. This PR unifies the arm64 and amd64 image builds into a single multi-platform image for openUC2/pallet to use, so that now I'm able to test the pallet starting with https://github.com/openUC2/pallet/pull/22.

This work is tracked in https://www.notion.so/Add-versioned-labels-to-ImSwitch-s-container-images-2724e612c78a8062aff2f70ebfecf961?source=copy_link and https://www.notion.so/Unify-ImSwitch-s-Docker-container-images-for-automatic-selection-of-host-platform-2794e612c78a80898da7db756d087e83?source=copy_link