### PR TITLE
Add device-admin iframe for reboot/shutdown management in SystemSettings

### DIFF
--- a/.github/workflows/test-uv.yml
+++ b/.github/workflows/test-uv.yml
@@ -70,8 +70,8 @@ jobs:
           uv pip list | grep psygnal || echo "psygnal not found"
           echo "Uninstalling psygnal..."
           uv pip uninstall psygnal || echo "psygnal uninstall failed (not installed)"
-          echo "Installing psygnal from source..."
-          uv pip install psygnal --system --no-binary :all:
+          echo "Installing pinned psygnal..."
+          uv pip install "psygnal==0.11.1" --system
           echo "Verifying installation..."
           python -c "import dataclasses_json; print('dataclasses_json imported successfully')" || echo "dataclasses_json import failed"
           python -c "import psygnal; print('psygnal imported successfully')" || echo "psygnal import failed"

--- a/.github/workflows/test-uv.yml
+++ b/.github/workflows/test-uv.yml
@@ -72,6 +72,9 @@ jobs:
           uv pip uninstall psygnal || echo "psygnal uninstall failed (not installed)"
           echo "Installing pinned psygnal..."
           uv pip install "psygnal==0.11.1" --system
+          # psygnal 0.11+ may ship compiled modules that break subclassing in ImSwitch.
+          # Decompile explicitly to force pure-Python modules.
+          python -c "import psygnal.utils; psygnal.utils.decompile()"
           echo "Verifying installation..."
           python -c "import dataclasses_json; print('dataclasses_json imported successfully')" || echo "dataclasses_json import failed"
           python -c "import psygnal; print('psygnal imported successfully')" || echo "psygnal import failed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           python3 -m pip install .
           # hacky workaround to ensure we get the right psygnal version: otherwise error: INTERNALERROR> TypeError: interpreted classes cannot inherit from compiled
           python3 -m pip uninstall psygnal -y || echo "psygnal uninstall failed (not installed)"
-          python3 -m pip install psygnal --no-binary :all:                
+          python3 -m pip install "psygnal==0.11.1"
           python3 -m pip install ruff pytest
         shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
           # hacky workaround to ensure we get the right psygnal version: otherwise error: INTERNALERROR> TypeError: interpreted classes cannot inherit from compiled
           python3 -m pip uninstall psygnal -y || echo "psygnal uninstall failed (not installed)"
           python3 -m pip install "psygnal==0.11.1"
+          # psygnal 0.11+ may ship compiled modules that break subclassing in ImSwitch.
+          # Decompile explicitly to force pure-Python modules.
+          python3 -c "import psygnal.utils; psygnal.utils.decompile()"
           python3 -m pip install ruff pytest
         shell: bash
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microscope-app",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "private": true,
   "homepage": "/imswitch/ui",
   "dependencies": {

--- a/frontend/src/components/SystemSettings.js
+++ b/frontend/src/components/SystemSettings.js
@@ -14,6 +14,7 @@ import {
   Alert,
   Chip,
   LinearProgress,
+  Link,
 } from "@mui/material";
 import {
   Computer,
@@ -21,6 +22,7 @@ import {
   Warning,
   CheckCircle,
   ErrorOutline,
+  OpenInNew,
 } from "@mui/icons-material";
 
 export default function SystemSettings() {
@@ -36,8 +38,11 @@ export default function SystemSettings() {
 
   // Safety toggles
   const [enableImSwitch, setEnableImSwitch] = useState(false);
-  const [enableRaspi, setEnableRaspi] = useState(false);
   const [isImSwitchRunning, setIsImSwitchRunning] = useState(false);
+  const [deviceAdminUrl] = useState(
+    () => `http://${hostIP}/admin/panel/boot/?mode=minimal&nav=hidden`,
+  );
+  const [deviceAdminLoaded, setDeviceAdminLoaded] = useState(false);
 
   const base = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController`;
   const activeUsage = storageState.status.active_device?.usage || null;
@@ -266,35 +271,66 @@ export default function SystemSettings() {
             </Typography>
           </Alert>
 
-          <FormControlLabel
-            control={
-              <Switch
-                checked={enableRaspi}
-                onChange={(e) => setEnableRaspi(e.target.checked)}
-              />
-            }
-            label="Enable Raspberry Pi reboot"
-            sx={{ mb: 2 }}
-          />
-
-          <Box sx={{ display: "flex", gap: 2 }}>
-            <Button
-              variant="contained"
-              color="error"
-              disabled={!enableRaspi || !isBackendConnected}
-              onClick={() => callEndpoint(`${base}/restartRaspi`)}
-            >
-              Reboot Raspberry Pi
-            </Button>
-
-            <Button
-              variant="outlined"
-              color="error"
-              disabled={!enableRaspi || !isBackendConnected}
-              onClick={() => callEndpoint(`${base}/shutdownRaspi`)}
-            >
-              Shutdown Raspberry Pi
-            </Button>
+          {/* Device-Admin iframe for reboot/shutdown */}
+          <Box sx={{ mb: 3 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              System Management
+            </Typography>
+            {deviceAdminLoaded ? (
+              <Box
+                sx={{
+                  border: "1px solid #e0e0e0",
+                  borderRadius: 1,
+                  overflow: "hidden",
+                  mb: 2,
+                }}
+              >
+                <iframe
+                  src={deviceAdminUrl}
+                  style={{
+                    width: "100%",
+                    height: "300px",
+                    border: "none",
+                    borderRadius: "4px",
+                  }}
+                  title="Device Admin Panel - Reboot/Shutdown"
+                  onLoad={() => setDeviceAdminLoaded(true)}
+                  onError={() => setDeviceAdminLoaded(false)}
+                  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+                />
+              </Box>
+            ) : (
+              <Box
+                sx={{
+                  border: "1px solid #424242",
+                  borderRadius: 1,
+                  p: 2,
+                  mb: 2,
+                  backgroundColor: "#2a2a2a",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 1,
+                }}
+              >
+                <Typography variant="body2" sx={{ color: "#b0b0b0", mb: 1 }}>
+                  Device admin panel not available. Please use the direct link:
+                </Typography>
+                <Link
+                  href={deviceAdminUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    color: "#64b5f6",
+                    "&:hover": { color: "#90caf9" },
+                  }}
+                >
+                  Reboot/Shutdown in device-admin <OpenInNew fontSize="small" />
+                </Link>
+              </Box>
+            )}
           </Box>
         </CardContent>
       </Card>

--- a/frontend/src/components/SystemSettings.js
+++ b/frontend/src/components/SystemSettings.js
@@ -42,13 +42,31 @@ export default function SystemSettings() {
   const [enableImSwitch, setEnableImSwitch] = useState(false);
   const [isImSwitchRunning, setIsImSwitchRunning] = useState(false);
   const deviceAdminUrl = (() => {
-    const url = new URL("/admin/panel/boot/", hostIP);
-    url.searchParams.set("mode", "minimal");
-    url.searchParams.set("nav", "hidden");
-    return url.toString();
+    if (!hostIP) {
+      return null;
+    }
+    try {
+      const url = new URL("/admin/panel/boot/", hostIP);
+      url.searchParams.set("mode", "minimal");
+      url.searchParams.set("nav", "hidden");
+      return url.toString();
+    } catch (e) {
+      console.error("Failed to construct device admin URL:", e);
+      return null;
+    }
   })();
   const canInspectDeviceAdmin =
-    new URL(deviceAdminUrl).origin === window.location.origin;
+    (() => {
+      if (!deviceAdminUrl) {
+        return false;
+      }
+      try {
+        return new URL(deviceAdminUrl).origin === window.location.origin;
+      } catch (e) {
+        console.error("Failed to inspect device admin URL:", e);
+        return false;
+      }
+    })();
   const [deviceAdminStatus, setDeviceAdminStatus] = useState("loading");
 
   const base = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController`;

--- a/frontend/src/components/SystemSettings.js
+++ b/frontend/src/components/SystemSettings.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
 import { getConnectionSettingsState } from "../state/slices/ConnectionSettingsSlice";
 import { getStorageState } from "../state/slices/StorageSlice";
@@ -26,6 +26,8 @@ import {
 } from "@mui/icons-material";
 
 export default function SystemSettings() {
+  const deviceAdminFrameRef = useRef(null);
+
   // Get connection settings from Redux
   const { ip: hostIP, apiPort: hostPort } = useSelector(
     getConnectionSettingsState,
@@ -39,13 +41,15 @@ export default function SystemSettings() {
   // Safety toggles
   const [enableImSwitch, setEnableImSwitch] = useState(false);
   const [isImSwitchRunning, setIsImSwitchRunning] = useState(false);
-  const [deviceAdminUrl] = useState(() => {
+  const deviceAdminUrl = (() => {
     const url = new URL("/admin/panel/boot/", hostIP);
     url.searchParams.set("mode", "minimal");
     url.searchParams.set("nav", "hidden");
     return url.toString();
-  });
-  const [deviceAdminLoaded, setDeviceAdminLoaded] = useState(false);
+  })();
+  const canInspectDeviceAdmin =
+    new URL(deviceAdminUrl).origin === window.location.origin;
+  const [deviceAdminStatus, setDeviceAdminStatus] = useState("loading");
 
   const base = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController`;
   const activeUsage = storageState.status.active_device?.usage || null;
@@ -117,6 +121,45 @@ export default function SystemSettings() {
     const intervalId = setInterval(checkImSwitchStatus, 10000);
     return () => clearInterval(intervalId);
   }, [base, isBackendConnected]);
+
+  useEffect(() => {
+    setDeviceAdminStatus(canInspectDeviceAdmin ? "loading" : "unavailable");
+  }, [canInspectDeviceAdmin, deviceAdminUrl]);
+
+  const handleDeviceAdminLoad = () => {
+    const iframe = deviceAdminFrameRef.current;
+
+    if (!iframe) {
+      setDeviceAdminStatus("ready");
+      return;
+    }
+
+    try {
+      const iframeDocument =
+        iframe.contentDocument || iframe.contentWindow?.document;
+      const iframeText = [
+        iframeDocument?.title || "",
+        iframeDocument?.body?.innerText || "",
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      const looksMissing =
+        iframeText.includes("404") ||
+        iframeText.includes("not found") ||
+        iframeText.includes("requested url was not found");
+
+      setDeviceAdminStatus(looksMissing ? "missing" : "ready");
+    } catch {
+      // Cross-origin iframe content cannot be inspected. In that case,
+      // treat a successful load as available.
+      setDeviceAdminStatus("ready");
+    }
+  };
+
+  const handleDeviceAdminError = () => {
+    setDeviceAdminStatus("unavailable");
+  };
 
   // Helper function to get disk usage color based on percentage
   const getDiskUsageColor = (usage) => {
@@ -279,30 +322,36 @@ export default function SystemSettings() {
             <Typography variant="subtitle2" sx={{ mb: 1 }}>
               System Management
             </Typography>
-            {deviceAdminLoaded ? (
-              <Box
-                sx={{
-                  border: "1px solid #e0e0e0",
-                  borderRadius: 1,
-                  overflow: "hidden",
-                  mb: 2,
-                }}
-              >
+            <Box
+              sx={{
+                display: deviceAdminStatus === "ready" ? "block" : "none",
+                border: "1px solid #424242",
+                borderRadius: 1,
+                overflow: "hidden",
+                mb: 2,
+                backgroundColor: "#2a2a2a",
+              }}
+            >
+              {canInspectDeviceAdmin && (
                 <iframe
+                  ref={deviceAdminFrameRef}
                   src={deviceAdminUrl}
                   style={{
                     width: "100%",
                     height: "300px",
                     border: "none",
                     borderRadius: "4px",
+                    display: "block",
+                    backgroundColor: "#2a2a2a",
                   }}
                   title="Device Admin Panel - Reboot/Shutdown"
-                  onLoad={() => setDeviceAdminLoaded(true)}
-                  onError={() => setDeviceAdminLoaded(false)}
+                  onLoad={handleDeviceAdminLoad}
+                  onError={handleDeviceAdminError}
                   sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
                 />
-              </Box>
-            ) : (
+              )}
+            </Box>
+            {deviceAdminStatus !== "ready" && (
               <Box
                 sx={{
                   border: "1px solid #424242",
@@ -316,7 +365,13 @@ export default function SystemSettings() {
                 }}
               >
                 <Typography variant="body2" sx={{ color: "#b0b0b0", mb: 1 }}>
-                  Device admin panel not available. Please use the direct link:
+                  {!canInspectDeviceAdmin
+                    ? "The admin panel is not available at the expected same-origin URL in this setup."
+                    : deviceAdminStatus === "missing"
+                      ? "The admin panel was not found at the expected URL for this setup."
+                      : deviceAdminStatus === "unavailable"
+                        ? "The admin panel could not be loaded from this setup."
+                        : "Loading the admin panel. If it does not appear, please use the direct link:"}
                 </Typography>
                 <Link
                   href={deviceAdminUrl}

--- a/frontend/src/components/SystemSettings.js
+++ b/frontend/src/components/SystemSettings.js
@@ -39,9 +39,12 @@ export default function SystemSettings() {
   // Safety toggles
   const [enableImSwitch, setEnableImSwitch] = useState(false);
   const [isImSwitchRunning, setIsImSwitchRunning] = useState(false);
-  const [deviceAdminUrl] = useState(
-    () => `http://${hostIP}/admin/panel/boot/?mode=minimal&nav=hidden`,
-  );
+  const [deviceAdminUrl] = useState(() => {
+    const url = new URL("/admin/panel/boot/", hostIP);
+    url.searchParams.set("mode", "minimal");
+    url.searchParams.set("nav", "hidden");
+    return url.toString();
+  });
   const [deviceAdminLoaded, setDeviceAdminLoaded] = useState(false);
 
   const base = `${hostIP}:${hostPort}/imswitch/api/UC2ConfigController`;

--- a/frontend/src/version.js
+++ b/frontend/src/version.js
@@ -2,4 +2,4 @@
  * Application version - manually synchronized with package.json
  * Update this when bumping version in package.json
  */
-export const APP_VERSION = "1.5.7";
+export const APP_VERSION = "1.5.8";


### PR DESCRIPTION
Add an iframe instead of the not working reboot buttons to the admin panel. 