### PR TITLE
Implement recording download functionality

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microscope-app",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microscope-app",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "@blockly/theme-dark": "^8.0.1",
         "@deck.gl/core": "^9.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microscope-app",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "homepage": "/imswitch/ui",
   "dependencies": {

--- a/frontend/src/components/LiveView.js
+++ b/frontend/src/components/LiveView.js
@@ -324,6 +324,23 @@ export default function LiveView({ setFileManagerInitialPath }) {
     showNotification(`Image downloaded (${label})`, "success");
   }
 
+  function triggerDownload(filePath, fallbackFileName = "capture") {
+    if (!filePath) return false;
+    const normalizedFilePath = `/${String(filePath).replace(/^\/+/, "")}`;
+    const downloadUrl = `${hostIP}:${hostPort}/imswitch/api/FileManager/download${encodeURI(normalizedFilePath)}`;
+    const downloadedFileName =
+      normalizedFilePath.split("/").pop() || fallbackFileName;
+
+    const link = document.createElement("a");
+    link.href = downloadUrl;
+    link.download = downloadedFileName;
+    link.style.display = "none";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    return true;
+  }
+
   function getFolderPath(path) {
     if (!path) return "/";
     const normalized = String(path).replace(/\\/g, "/");
@@ -365,11 +382,47 @@ export default function LiveView({ setFileManagerInitialPath }) {
       if (!response.ok) {
         throw new Error(`Stop recording failed: ${response.status}`);
       }
+
+      let data = null;
+      try {
+        data = await response.json();
+      } catch {
+        data = null;
+      }
+
       setIsRecording(false);
+
+      const recordedPath = data?.relativeFilePath || data?.fullPath || null;
+      if (recordedPath) {
+        const { filePath } = deriveCapturePaths(data);
+        dispatch(liveViewSlice.setLastCapturePath(filePath));
+      }
+
       showNotification("Recording saved", "success");
+      return data;
     } catch (error) {
       console.error("Stop recording failed:", error);
       showNotification("Recording stop failed", "error");
+      return null;
+    }
+  };
+
+  const stopRecAndDownload = async () => {
+    const data = await stopRec();
+    if (!data) return;
+
+    const filePath = data.relativeFilePath || null;
+    if (!filePath) {
+      showNotification(
+        "Recording stopped, but no downloadable file was returned",
+        "warning",
+      );
+      return;
+    }
+
+    const downloaded = triggerDownload(filePath, "recording.mp4");
+    if (downloaded) {
+      showNotification("Recording downloaded", "success");
     }
   };
 
@@ -466,6 +519,7 @@ export default function LiveView({ setFileManagerInitialPath }) {
             isRecording={isRecording}
             onStartRecord={startRec}
             onStopRecord={stopRec}
+            onStopRecordAndDownload={stopRecAndDownload}
             onGoToFolder={handleGoToFolder}
             lastCapturePath={lastCapturePath}
           />

--- a/frontend/src/components/StreamControls.js
+++ b/frontend/src/components/StreamControls.js
@@ -13,6 +13,7 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
+  Tooltip,
   Switch,
   FormControlLabel,
 } from "@mui/material";
@@ -42,6 +43,7 @@ export default function StreamControls({
   isRecording,
   onStartRecord,
   onStopRecord,
+  onStopRecordAndDownload,
   onGoToFolder,
   lastCapturePath,
 }) {
@@ -436,7 +438,7 @@ export default function StreamControls({
             display: "flex",
             gap: 1,
             alignItems: "center",
-            flexWrap: "wrap",
+            flexWrap: "nowrap",
           }}
         >
           <Typography
@@ -503,6 +505,30 @@ export default function StreamControls({
               Stop
             </Button>
           )}
+
+          <Tooltip
+            title={isRecording ? "" : "Please start a recording first"}
+            arrow
+          >
+            <span>
+              <Button
+                variant="contained"
+                color="warning"
+                size="small"
+                onClick={onStopRecordAndDownload}
+                startIcon={<GetApp />}
+                disabled={!isRecording}
+                sx={{
+                  whiteSpace: "nowrap",
+                  height: 40,
+                  minHeight: 40,
+                  width: 160,
+                }}
+              >
+                Stop & Download
+              </Button>
+            </span>
+          </Tooltip>
         </Box>
       </Box>
 

--- a/frontend/src/version.js
+++ b/frontend/src/version.js
@@ -2,4 +2,4 @@
  * Application version - manually synchronized with package.json
  * Update this when bumping version in package.json
  */
-export const APP_VERSION = "1.6.0";
+export const APP_VERSION = "1.6.1";

--- a/imswitch/imcontrol/controller/controllers/RecordingController.py
+++ b/imswitch/imcontrol/controller/controllers/RecordingController.py
@@ -372,7 +372,7 @@ class RecordingController(ImConWidgetController):
             try:
                 normalized_relative = os.path.relpath(full_path, data_root).replace("\\", "/")
                 relative_file_path = f"/{normalized_relative}"
-                relative_path = f"/{os.path.dirname(normalized_relative)}" if os.path.dirname(normalized_relative) else "/"
+                relative_path = os.path.dirname(normalized_relative)
             except Exception:
                 relative_file_path = None
                 relative_path = None

--- a/imswitch/imcontrol/controller/controllers/RecordingController.py
+++ b/imswitch/imcontrol/controller/controllers/RecordingController.py
@@ -355,6 +355,36 @@ class RecordingController(ImConWidgetController):
             self.stop_streaming_recording()
         self._commChannel.sigRecordingEnded.emit()
 
+    def _build_recording_response(self) -> Dict[str, Any]:
+        """Build path metadata for the current/last recording output."""
+        save_format = self.recordingArgs.get("saveFormat") if isinstance(self.recordingArgs, dict) else None
+        data_root = dirtools.UserFileDirs.getValidatedDataPath()
+
+        full_path: Optional[str] = None
+        if save_format == SaveFormat.MP4:
+            full_path = f"{self.savename}.mp4"
+        elif self.savename:
+            full_path = self.savename
+
+        relative_file_path = None
+        relative_path = None
+        if full_path:
+            try:
+                normalized_relative = os.path.relpath(full_path, data_root).replace("\\", "/")
+                relative_file_path = f"/{normalized_relative}"
+                relative_path = f"/{os.path.dirname(normalized_relative)}" if os.path.dirname(normalized_relative) else "/"
+            except Exception:
+                relative_file_path = None
+                relative_path = None
+
+        return {
+            "fullPath": full_path,
+            "relativePath": relative_path,
+            "relativeFilePath": relative_file_path,
+            "saveFormat": int(save_format.value) if isinstance(save_format, SaveFormat) else None,
+            "isDownloadableFile": bool(relative_file_path and save_format == SaveFormat.MP4),
+        }
+
 
     def recordingStarted(self):
         pass
@@ -598,7 +628,7 @@ class RecordingController(ImConWidgetController):
         return Response(im_bytes, headers=headers, media_type="image/png")
 
     @APIExport(runOnUIThread=True)
-    def startRecording(self, mSaveFormat: int = SaveFormat.TIFF, fileName: Optional[str] = None) -> None:
+    def startRecording(self, mSaveFormat: int = SaveFormat.TIFF, fileName: Optional[str] = None) -> Dict[str, Any]:
         """Starts recording with the set settings to the set file path using RecordingService.
         
         Parameters:
@@ -619,7 +649,7 @@ class RecordingController(ImConWidgetController):
 
         # we probably call from the FASTAPI server
         if self.recording:  # Already recording
-            return
+            return self._build_recording_response()
 
         # Use ISO 8601 date format, consistent with snap() method
         timeStampDay = datetime.datetime.now().strftime("%Y-%m-%d")
@@ -650,13 +680,16 @@ class RecordingController(ImConWidgetController):
         self._start_continuous_recording(mSaveFormat)
         self.recording = True
         self.endedRecording = False
+        return self._build_recording_response()
 
     @APIExport(runOnUIThread=True)
-    def stopRecording(self) -> None:
+    def stopRecording(self) -> Dict[str, Any]:
         """Stops recording using RecordingService."""
+        recording_result = self._build_recording_response()
         self.recording = False
         self.endedRecording = True
         self._stop_recording()
+        return recording_result
 
     @APIExport(runOnUIThread=False)
     def isRecording(self) -> bool:


### PR DESCRIPTION
This pull request introduces a new "Stop & Download" feature for recordings in the frontend, allowing users to immediately download a recording after stopping it. It also enhances the backend API to return detailed metadata about recordings, improving the integration between frontend and backend. Additionally, the application version is bumped to 1.6.1.

**Frontend: Recording Download Workflow**

* Added a `triggerDownload` function in `LiveView.js` to programmatically download a file given its path, used for the new stop-and-download workflow.
* Implemented `stopRecAndDownload`, which stops the recording and, upon success, triggers the download