### PR TITLE
feat(live-view): add software zoom/pan with pinch, wheel, and reset c…

### DIFF
--- a/frontend/src/axon/LiveViewControlWrapper.js
+++ b/frontend/src/axon/LiveViewControlWrapper.js
@@ -82,9 +82,12 @@ const LiveViewControlWrapper = ({
     liveStreamState.backendCapabilities.webglSupported &&
     !liveStreamState.isLegacyBackend &&
     liveStreamState.imageFormat !== "jpeg";
+  const canHover =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(hover: hover)").matches;
   const showInteractiveControls =
-    showPositionController ||
-    (isHovering && window.matchMedia("(hover: hover)").matches);
+    showPositionController || (isHovering && canHover);
 
   // Handle double-click for stage movement
   const handleImageDoubleClick = async (

--- a/frontend/src/axon/LiveViewControlWrapper.js
+++ b/frontend/src/axon/LiveViewControlWrapper.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import {
   IconButton,
   Tooltip,
@@ -61,11 +61,16 @@ const LiveViewControlWrapper = ({
   const objectiveState = useSelector(objectiveSlice.getObjectiveState);
   const liveStreamState = useSelector(liveStreamSlice.getLiveStreamState);
   const liveViewState = useSelector(liveViewSlice.getLiveViewState);
+  const transformFrameRef = useRef(null);
+  const pendingTransformRef = useRef({
+    scale: 1,
+    positionX: 0,
+    positionY: 0,
+  });
 
   // Get persistent position controller visibility from Redux
   const showPositionController = liveViewState.showPositionController || false;
   const [isHovering, setIsHovering] = useState(false);
-  const [zoomPercent, setZoomPercent] = useState(100);
   const [transformState, setTransformState] = useState({
     scale: 1,
     positionX: 0,
@@ -88,6 +93,45 @@ const LiveViewControlWrapper = ({
     window.matchMedia("(hover: hover)").matches;
   const showInteractiveControls =
     showPositionController || (isHovering && canHover);
+  const zoomPercent = Math.round(transformState.scale * 100);
+
+  useEffect(() => {
+    return () => {
+      if (transformFrameRef.current !== null) {
+        cancelAnimationFrame(transformFrameRef.current);
+      }
+    };
+  }, []);
+
+  const handleTransformed = useCallback((_, state) => {
+    pendingTransformRef.current = {
+      scale: state.scale,
+      positionX: state.positionX,
+      positionY: state.positionY,
+    };
+
+    if (transformFrameRef.current !== null) {
+      return;
+    }
+
+    transformFrameRef.current = requestAnimationFrame(() => {
+      transformFrameRef.current = null;
+
+      setTransformState((prevState) => {
+        const nextState = pendingTransformRef.current;
+
+        if (
+          Math.abs(prevState.scale - nextState.scale) < 0.001 &&
+          Math.abs(prevState.positionX - nextState.positionX) < 0.001 &&
+          Math.abs(prevState.positionY - nextState.positionY) < 0.001
+        ) {
+          return prevState;
+        }
+
+        return nextState;
+      });
+    });
+  }, []);
 
   // Handle double-click for stage movement
   const handleImageDoubleClick = async (
@@ -402,14 +446,7 @@ const LiveViewControlWrapper = ({
             panning={{
               velocityDisabled: true,
             }}
-            onTransformed={(_, state) => {
-              setZoomPercent(Math.round(state.scale * 100));
-              setTransformState({
-                scale: state.scale,
-                positionX: state.positionX,
-                positionY: state.positionY,
-              });
-            }}
+            onTransformed={handleTransformed}
           >
             {({ zoomIn, zoomOut, resetTransform }) => {
               const hasTransform =
@@ -504,7 +541,6 @@ const LiveViewControlWrapper = ({
                           </Tooltip>
                         </Stack>
                       </Stack>
-
                     </>
                   )}
                 </>

--- a/frontend/src/axon/LiveViewControlWrapper.js
+++ b/frontend/src/axon/LiveViewControlWrapper.js
@@ -6,6 +6,7 @@ import {
   Chip,
   Typography,
   CircularProgress,
+  Stack,
 } from "@mui/material";
 import { keyframes } from "@mui/system";
 import {
@@ -13,7 +14,11 @@ import {
   GamepadOutlined,
   FiberManualRecord,
   Videocam,
+  ZoomIn,
+  ZoomOut,
+  RestartAlt,
 } from "@mui/icons-material";
+import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import LiveViewComponent from "./LiveViewComponent";
 import LiveViewerGL from "../components/LiveViewerGL";
 import WebRTCViewer from "./WebRTCViewer";
@@ -60,6 +65,12 @@ const LiveViewControlWrapper = ({
   // Get persistent position controller visibility from Redux
   const showPositionController = liveViewState.showPositionController || false;
   const [isHovering, setIsHovering] = useState(false);
+  const [zoomPercent, setZoomPercent] = useState(100);
+  const [transformState, setTransformState] = useState({
+    scale: 1,
+    positionX: 0,
+    positionY: 0,
+  });
 
   // Determine which viewer to use based on stream format
   // - WebRTC: Use WebRTCViewer for real-time low-latency streaming
@@ -71,6 +82,9 @@ const LiveViewControlWrapper = ({
     liveStreamState.backendCapabilities.webglSupported &&
     !liveStreamState.isLegacyBackend &&
     liveStreamState.imageFormat !== "jpeg";
+  const showInteractiveControls =
+    showPositionController ||
+    (isHovering && window.matchMedia("(hover: hover)").matches);
 
   // Handle double-click for stage movement
   const handleImageDoubleClick = async (
@@ -136,6 +150,78 @@ const LiveViewControlWrapper = ({
     },
     [onImageLoad],
   );
+
+  const renderViewer = () => {
+    if (useWebRTC && liveViewState.isStreamRunning) {
+      return (
+        <WebRTCViewer
+          key="webrtc-viewer"
+          onClick={onClick}
+          onDoubleClick={handleImageDoubleClick}
+          onImageLoad={handleImageLoadInternal}
+        />
+      );
+    }
+
+    if (!liveViewState.isStreamRunning) {
+      return (
+        <Box
+          sx={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 2,
+          }}
+        >
+          <Videocam
+            sx={{
+              fontSize: 80,
+              color: "text.disabled",
+            }}
+          />
+          <Typography
+            variant="h6"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
+            Stream nicht aktiv
+          </Typography>
+          <CircularProgress
+            size={24}
+            sx={{
+              color: "text.disabled",
+            }}
+          />
+        </Box>
+      );
+    }
+
+    if (useWebGL) {
+      return (
+        <LiveViewerGL
+          onClick={onClick}
+          onDoubleClick={handleImageDoubleClick}
+          onImageLoad={handleImageLoadInternal}
+          overlayContent={overlayContent}
+          enableViewportControls={false}
+        />
+      );
+    }
+
+    return (
+      <LiveViewComponent
+        useFastMode={useFastMode}
+        onClick={onClick}
+        onDoubleClick={handleImageDoubleClick}
+        onImageLoad={handleImageLoadInternal}
+        overlayContent={overlayContent}
+      />
+    );
+  };
 
   return (
     <div
@@ -293,70 +379,142 @@ const LiveViewControlWrapper = ({
           }}
         />
 
-        {/* Select appropriate viewer based on stream format */}
-        {/* WebRTC: Only render when stream is running to force remount on start/stop */}
-        {useWebRTC && liveViewState.isStreamRunning ? (
-          <WebRTCViewer
-            key="webrtc-viewer" // Force new instance on remount
-            onClick={onClick}
-            onDoubleClick={handleImageDoubleClick}
-            onImageLoad={handleImageLoadInternal}
-          />
-        ) : !liveViewState.isStreamRunning ? (
-          // Placeholder when stream is not running
-          <Box
-            sx={{
-              width: "100%",
-              height: "100%",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: 2,
+        {liveViewState.isStreamRunning ? (
+          <TransformWrapper
+            key={`zoom-shell-${liveStreamState.imageFormat}-${liveViewState.isStreamRunning}`}
+            initialScale={1}
+            minScale={1}
+            maxScale={8}
+            centerOnInit
+            limitToBounds={false}
+            smooth
+            doubleClick={{ disabled: true }}
+            wheel={{
+              step: 0.15,
+              smoothStep: 0.01,
+              wheelDisabled: false,
+              touchPadDisabled: false,
+            }}
+            pinch={{ step: 5 }}
+            panning={{
+              velocityDisabled: true,
+            }}
+            onTransformed={(_, state) => {
+              setZoomPercent(Math.round(state.scale * 100));
+              setTransformState({
+                scale: state.scale,
+                positionX: state.positionX,
+                positionY: state.positionY,
+              });
             }}
           >
-            <Videocam
-              sx={{
-                fontSize: 80,
-                color: "text.disabled",
-              }}
-            />
-            <Typography
-              variant="h6"
-              sx={{
-                color: "text.secondary",
-              }}
-            >
-              Stream nicht aktiv
-            </Typography>
-            <CircularProgress
-              size={24}
-              sx={{
-                color: "text.disabled",
-              }}
-            />
-          </Box>
-        ) : useWebGL ? (
-          <LiveViewerGL
-            onClick={onClick}
-            onDoubleClick={handleImageDoubleClick}
-            onImageLoad={handleImageLoadInternal}
-            overlayContent={overlayContent}
-          />
+            {({ zoomIn, zoomOut, resetTransform }) => {
+              const hasTransform =
+                Math.abs(transformState.scale - 1) > 0.01 ||
+                Math.abs(transformState.positionX) > 0.5 ||
+                Math.abs(transformState.positionY) > 0.5;
+
+              return (
+                <>
+                  <TransformComponent
+                    wrapperStyle={{
+                      width: "100%",
+                      height: "100%",
+                      touchAction: "none",
+                    }}
+                    contentStyle={{
+                      width: "100%",
+                      height: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    {renderViewer()}
+                  </TransformComponent>
+
+                  {showInteractiveControls && (
+                    <>
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        sx={{
+                          position: "absolute",
+                          right: 12,
+                          bottom: 12,
+                          zIndex: 4,
+                          alignItems: "center",
+                        }}
+                      >
+                        <Chip
+                          label={`Zoom ${zoomPercent}%`}
+                          size="small"
+                          color={hasTransform ? "primary" : "default"}
+                          sx={{
+                            backgroundColor: hasTransform
+                              ? "primary.main"
+                              : "rgba(0, 0, 0, 0.55)",
+                            color: "white",
+                            fontWeight: 700,
+                            backdropFilter: "blur(4px)",
+                          }}
+                        />
+                        <Stack
+                          direction="row"
+                          spacing={0.5}
+                          sx={{
+                            p: 0.5,
+                            borderRadius: 999,
+                            backgroundColor: "rgba(0, 0, 0, 0.55)",
+                            backdropFilter: "blur(4px)",
+                          }}
+                        >
+                          <Tooltip title="Zoom out">
+                            <IconButton
+                              size="small"
+                              onClick={() => zoomOut(0.2)}
+                              sx={{ color: "white" }}
+                            >
+                              <ZoomOut fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Reset view">
+                            <span>
+                              <IconButton
+                                size="small"
+                                onClick={() => resetTransform(200)}
+                                disabled={!hasTransform}
+                                sx={{ color: "white" }}
+                              >
+                                <RestartAlt fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                          <Tooltip title="Zoom in">
+                            <IconButton
+                              size="small"
+                              onClick={() => zoomIn(0.2)}
+                              sx={{ color: "white" }}
+                            >
+                              <ZoomIn fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        </Stack>
+                      </Stack>
+
+                    </>
+                  )}
+                </>
+              );
+            }}
+          </TransformWrapper>
         ) : (
-          <LiveViewComponent
-            useFastMode={useFastMode}
-            onClick={onClick}
-            onDoubleClick={handleImageDoubleClick}
-            onImageLoad={handleImageLoadInternal}
-            overlayContent={overlayContent}
-          />
+          renderViewer()
         )}
       </Box>
 
       {/* Position controller - shown on hover OR when toggled on */}
-      {(showPositionController ||
-        (isHovering && window.matchMedia("(hover: hover)").matches)) && (
+      {showInteractiveControls && (
         <div
           style={{
             position: "absolute",

--- a/frontend/src/components/LiveViewerGL.js
+++ b/frontend/src/components/LiveViewerGL.js
@@ -39,7 +39,7 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
 
   // Mouse interaction state
   const [isDragging, setIsDragging] = useState(false);
-  const [lastMousePos, setLastMousePos] = useState({ x: 0, y: 0 });
+  const lastMousePosRef = useRef({ x: 0, y: 0 });
   
   // FPS counter
   const fpsCounterRef = useRef({
@@ -492,7 +492,7 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
     // Only handle left mouse button for panning
     if (e.button === 0) {
       setIsDragging(true);
-      setLastMousePos({ x: e.clientX, y: e.clientY });
+      lastMousePosRef.current = { x: e.clientX, y: e.clientY };
       e.preventDefault();
     }
     console.log('Mouse down, xy:', e.clientX, e.clientY);
@@ -505,8 +505,8 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const deltaX = e.clientX - lastMousePos.x;
-    const deltaY = e.clientY - lastMousePos.y;
+    const deltaX = e.clientX - lastMousePosRef.current.x;
+    const deltaY = e.clientY - lastMousePosRef.current.y;
     
     // Convert pixel movement to normalized coordinates
     const rect = canvas.getBoundingClientRect();
@@ -519,9 +519,9 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
       translateY: prev.translateY + normalizedDeltaY / prev.scale
     }));
     
-    setLastMousePos({ x: e.clientX, y: e.clientY });
+    lastMousePosRef.current = { x: e.clientX, y: e.clientY };
     e.preventDefault();
-  }, [enableViewportControls, isDragging, lastMousePos]);
+  }, [enableViewportControls, isDragging]);
 
   const handleMouseUp = useCallback((e) => {
     if (!enableViewportControls) {
@@ -929,8 +929,8 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
       const canvas = canvasRef.current;
       if (!canvas) return;
 
-      const deltaX = e.clientX - lastMousePos.x;
-      const deltaY = e.clientY - lastMousePos.y;
+      const deltaX = e.clientX - lastMousePosRef.current.x;
+      const deltaY = e.clientY - lastMousePosRef.current.y;
       
       // Convert pixel movement to normalized coordinates
       const rect = canvas.getBoundingClientRect();
@@ -943,7 +943,7 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
         translateY: prev.translateY + normalizedDeltaY / prev.scale
       }));
       
-      setLastMousePos({ x: e.clientX, y: e.clientY });
+      lastMousePosRef.current = { x: e.clientX, y: e.clientY };
       e.preventDefault();
     };
 
@@ -966,7 +966,7 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
       document.removeEventListener('mouseup', handleGlobalMouseUp);
       document.removeEventListener('contextmenu', handleGlobalMouseUp);
     };
-  }, [enableViewportControls, isDragging, lastMousePos]);
+  }, [enableViewportControls, isDragging]);
 
   // Calculate display dimensions to maximize width while maintaining aspect ratio
   const getDisplayDimensions = useCallback(() => {

--- a/frontend/src/components/LiveViewerGL.js
+++ b/frontend/src/components/LiveViewerGL.js
@@ -14,6 +14,7 @@ import { processUC2FPacket, processUC2FPacketWithMetadata, checkFeatureSupport }
  * @param {function} onImageLoad - Callback when image dimensions change: (width, height)
  * @param {function} onHudDataUpdate - Callback for HUD data updates
  * @param {React.ReactNode} overlayContent - Optional overlay content to render on top of the canvas
+ * @param {boolean} enableViewportControls - Whether internal viewport interaction is enabled. When false, internal wheel/pan handlers and the reset button are disabled.
  */
 const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, overlayContent, enableViewportControls = true }) => {
   const dispatch = useDispatch();

--- a/frontend/src/components/LiveViewerGL.js
+++ b/frontend/src/components/LiveViewerGL.js
@@ -15,7 +15,7 @@ import { processUC2FPacket, processUC2FPacketWithMetadata, checkFeatureSupport }
  * @param {function} onHudDataUpdate - Callback for HUD data updates
  * @param {React.ReactNode} overlayContent - Optional overlay content to render on top of the canvas
  */
-const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, overlayContent }) => {
+const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, overlayContent, enableViewportControls = true }) => {
   const dispatch = useDispatch();
   const liveStreamState = useSelector(liveStreamSlice.getLiveStreamState);
   
@@ -484,6 +484,10 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
 
   // Mouse event handlers for zoom and pan
   const handleMouseDown = useCallback((e) => {
+    if (!enableViewportControls) {
+      return;
+    }
+
     // Only handle left mouse button for panning
     if (e.button === 0) {
       setIsDragging(true);
@@ -491,9 +495,10 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
       e.preventDefault();
     }
     console.log('Mouse down, xy:', e.clientX, e.clientY);
-  }, []);
+  }, [enableViewportControls]);
 
   const handleMouseMove = useCallback((e) => {
+    if (!enableViewportControls) return;
     if (!isDragging) return;
     
     const canvas = canvasRef.current;
@@ -515,13 +520,17 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
     
     setLastMousePos({ x: e.clientX, y: e.clientY });
     e.preventDefault();
-  }, [isDragging, lastMousePos]);
+  }, [enableViewportControls, isDragging, lastMousePos]);
 
   const handleMouseUp = useCallback((e) => {
+    if (!enableViewportControls) {
+      return;
+    }
+
     console.log('Mouse up');
     setIsDragging(false);
     e.preventDefault();
-  }, []);
+  }, [enableViewportControls]);
 
   // Canvas2D fallback rendering
   const renderCanvas2D = useCallback((u16Data, width, height) => {
@@ -803,6 +812,10 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
 
   // Handle mouse interactions for zoom/pan
   const handleWheel = useCallback((event) => {
+    if (!enableViewportControls) {
+      return;
+    }
+
     event.preventDefault();
     
     const canvas = canvasRef.current;
@@ -829,7 +842,7 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
         translateY: newTranslateY
       };
     });
-  }, []);
+  }, [enableViewportControls]);
 
   const handleDoubleClick = useCallback((event) => {
     const canvas = canvasRef.current;
@@ -940,7 +953,7 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
       }
     };
 
-    if (isDragging) {
+    if (enableViewportControls && isDragging) {
       document.addEventListener('mousemove', handleGlobalMouseMove);
       document.addEventListener('mouseup', handleGlobalMouseUp);
       // Prevent context menu during drag
@@ -952,7 +965,7 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
       document.removeEventListener('mouseup', handleGlobalMouseUp);
       document.removeEventListener('contextmenu', handleGlobalMouseUp);
     };
-  }, [isDragging, lastMousePos]);
+  }, [enableViewportControls, isDragging, lastMousePos]);
 
   // Calculate display dimensions to maximize width while maintaining aspect ratio
   const getDisplayDimensions = useCallback(() => {
@@ -1000,7 +1013,6 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
         height={imageSize.height || 600}
         style={{
           cursor: isDragging ? 'grabbing' : (onClick ? 'crosshair' : 'grab'),
-          border: '2px solid red',
           zIndex: 1,
           display: 'block',
           width: displayDimensions.width,
@@ -1035,28 +1047,29 @@ const LiveViewerGL = ({ onClick, onDoubleClick, onImageLoad, onHudDataUpdate, ov
         </Box>
       )}
       
-      {/* Reset view button */}
-      <Box 
-        sx={{ 
-          position: 'absolute', 
-          bottom: 10, 
-          right: 10,
-          opacity: 0.8,
-          '&:hover': { opacity: 1 },
-          cursor: 'pointer',
-          bgcolor: 'primary.main',
-          color: 'primary.contrastText',
-          px: 2,
-          py: 1,
-          borderRadius: 1,
-          boxShadow: 2, 
-          zIndex: 3,
+      {enableViewportControls && (
+        <Box 
+          sx={{ 
+            position: 'absolute', 
+            bottom: 10, 
+            right: 10,
+            opacity: 0.8,
+            '&:hover': { opacity: 1 },
+            cursor: 'pointer',
+            bgcolor: 'primary.main',
+            color: 'primary.contrastText',
+            px: 2,
+            py: 1,
+            borderRadius: 1,
+            boxShadow: 2, 
+            zIndex: 3,
 
-        }}
-        onClick={resetView}
-      >
-        <Typography variant="body2" fontWeight="bold">Reset View (1:1)</Typography>
-      </Box>
+          }}
+          onClick={resetView}
+        >
+          <Typography variant="body2" fontWeight="bold">Reset View (1:1)</Typography>
+        </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
feat(live-view): add software zoom/pan with pinch, wheel, and reset controls

- Wrap live view in TransformWrapper (react-zoom-pan-pinch) for pinch-to-zoom, mouse wheel, and trackpad zoom/pan support
- Show zoom percentage chip and zoom in/out/reset buttons in bottom-right corner
- Reset button activates on pan as well as zoom
- Controls visibility tied to hover + Gamepad pin button state
- Disable internal WebGL viewport controls when outer wrapper handles zoom/pan