### PR TITLE
Populate version strings from CI

### DIFF
--- a/.github/workflows/build-docker-server.yaml
+++ b/.github/workflows/build-docker-server.yaml
@@ -108,9 +108,9 @@ jobs:
             ACTUAL_SHA="${{ github.sha }}"
           fi
 
-          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA" || printf "")"
+          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA" 2>/dev/null || printf "")"
           VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA")"
-          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'td%Y%m%d-tt%H%M%S' "$ACTUAL_SHA")"
+          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'t%Y%m%d%H%M%S' "$ACTUAL_SHA")"
 
           if [[ "$VERSION" != "$TAG" ]]; then
             VERSION="$VERSION-$TIMESTAMP"

--- a/.github/workflows/build-docker-server.yaml
+++ b/.github/workflows/build-docker-server.yaml
@@ -45,6 +45,9 @@ jobs:
           # Don't download unnecessary data:
           fetch-depth: 0
           filter: 'blob:none'
+          # We fetch tags so that the staged pallet bundle has a record of ancestral tags, for
+          # pseudoversion string generation:
+          fetch-tags: true
 
       - name: Wait for frontend to build
         id: wait-build-frontend
@@ -91,6 +94,34 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine version string
+        id: version-string
+        run: |
+          # Get the SHA of the actual commit (not the fake merge commit) on PR-triggered runs
+          # (refer to https://stackoverflow.com/a/68068674/23202949):
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            ACTUAL_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # Note: we want to have a SHA to check out even in merge queues, so we always fall back
+            # to a SHA even if it's a fictional SHA detached from any branches:
+            ACTUAL_SHA="${{ github.sha }}"
+          fi
+
+          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA")"
+          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA)"
+          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'%Y%m%d.%H%M%S' "$ACTUAL_SHA")"
+
+          if [[ "$VERSION" != "$TAG" ]]; then
+            VERSION="$VERSION-$TIMESTAMP"
+            if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
+              # We're in a pull request
+              VERSION="$VERSION-pr${{ github.event.pull_request.number }}"
+            fi
+          fi
+
+          echo "version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build and push by digest
         id: build

--- a/.github/workflows/build-docker-server.yaml
+++ b/.github/workflows/build-docker-server.yaml
@@ -40,12 +40,8 @@ jobs:
             gha-runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.gha-runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
-          # We check out the PR's HEAD commit instead of its merge commit for traceability when
-          # determining the build output's version string; if the CI run isn't a PR, we'll just use
-          # the default ref via an empty string:
-          ref: ${{ github.event.pull_request.head.sha }}
           # Don't download unnecessary data:
           fetch-depth: 0
           filter: 'blob:none'
@@ -102,9 +98,19 @@ jobs:
       - name: Determine version string
         id: version-string
         run: |
-          TAG="$(git describe --tags --exact-match --match "v*")"
-          VERSION="$(git describe --tags --match "v*" --abbrev=7
-          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'%Y%m%d.%H%M%S')"
+          # Get the SHA of the actual commit (not the fake merge commit) on PR-triggered runs
+          # (refer to https://stackoverflow.com/a/68068674/23202949):
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            ACTUAL_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # Note: we want to have a SHA to check out even in merge queues, so we always fall back
+            # to a SHA even if it's a fictional SHA detached from any branches:
+            ACTUAL_SHA="${{ github.sha }}"
+          fi
+
+          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA" || printf "")"
+          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA)"
+          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'td%Y%m%d-tt%H%M%S' "$ACTUAL_SHA")"
 
           if [[ "$VERSION" != "$TAG" ]]; then
             VERSION="$VERSION-$TIMESTAMP"

--- a/.github/workflows/build-docker-server.yaml
+++ b/.github/workflows/build-docker-server.yaml
@@ -123,6 +123,12 @@ jobs:
           echo "version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Record version
+        run: |
+          VERSION="${{ steps.version-string.outputs.version }}"
+          echo "version = \"$VERSION\"" > ./imswitch/version.py
+          cat ./imswitch/version.py
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6

--- a/.github/workflows/build-docker-server.yaml
+++ b/.github/workflows/build-docker-server.yaml
@@ -40,8 +40,12 @@ jobs:
             gha-runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.gha-runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          # We check out the PR's HEAD commit instead of its merge commit for traceability when
+          # determining the build output's version string; if the CI run isn't a PR, we'll just use
+          # the default ref via an empty string:
+          ref: ${{ github.event.pull_request.head.sha }}
           # Don't download unnecessary data:
           fetch-depth: 0
           filter: 'blob:none'
@@ -98,19 +102,9 @@ jobs:
       - name: Determine version string
         id: version-string
         run: |
-          # Get the SHA of the actual commit (not the fake merge commit) on PR-triggered runs
-          # (refer to https://stackoverflow.com/a/68068674/23202949):
-          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            ACTUAL_SHA="${{ github.event.pull_request.head.sha }}"
-          else
-            # Note: we want to have a SHA to check out even in merge queues, so we always fall back
-            # to a SHA even if it's a fictional SHA detached from any branches:
-            ACTUAL_SHA="${{ github.sha }}"
-          fi
-
-          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA")"
-          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA)"
-          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'%Y%m%d.%H%M%S' "$ACTUAL_SHA")"
+          TAG="$(git describe --tags --exact-match --match "v*")"
+          VERSION="$(git describe --tags --match "v*" --abbrev=7
+          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'%Y%m%d.%H%M%S')"
 
           if [[ "$VERSION" != "$TAG" ]]; then
             VERSION="$VERSION-$TIMESTAMP"

--- a/.github/workflows/build-docker-server.yaml
+++ b/.github/workflows/build-docker-server.yaml
@@ -109,7 +109,7 @@ jobs:
           fi
 
           TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA" || printf "")"
-          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA)"
+          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA")"
           TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'td%Y%m%d-tt%H%M%S' "$ACTUAL_SHA")"
 
           if [[ "$VERSION" != "$TAG" ]]; then

--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -20,8 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          # We check out the PR's HEAD commit instead of its merge commit for traceability when
+          # determining the build output's version string; if the CI run isn't a PR, we'll just use
+          # the default ref via an empty string:
+          ref: ${{ github.event.pull_request.head.sha }}
           # This repo has tons of cruft in its history, so we try to only fetch files we actually need:
           fetch-depth: 0
           filter: 'blob:none'
@@ -43,19 +47,9 @@ jobs:
       - name: Determine version string
         id: version-string
         run: |
-          # Get the SHA of the actual commit (not the fake merge commit) on PR-triggered runs
-          # (refer to https://stackoverflow.com/a/68068674/23202949):
-          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            ACTUAL_SHA="${{ github.event.pull_request.head.sha }}"
-          else
-            # Note: we want to have a SHA to check out even in merge queues, so we always fall back
-            # to a SHA even if it's a fictional SHA detached from any branches:
-            ACTUAL_SHA="${{ github.sha }}"
-          fi
-
-          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA")"
-          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA)"
-          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'%Y%m%d.%H%M%S' "$ACTUAL_SHA")"
+          TAG="$(git describe --tags --exact-match --match "v*")"
+          VERSION="$(git describe --tags --match "v*" --abbrev=7
+          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'%Y%m%d.%H%M%S')"
 
           if [[ "$VERSION" != "$TAG" ]]; then
             VERSION="$VERSION-$TIMESTAMP"

--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -20,12 +20,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
-          # We check out the PR's HEAD commit instead of its merge commit for traceability when
-          # determining the build output's version string; if the CI run isn't a PR, we'll just use
-          # the default ref via an empty string:
-          ref: ${{ github.event.pull_request.head.sha }}
           # This repo has tons of cruft in its history, so we try to only fetch files we actually need:
           fetch-depth: 0
           filter: 'blob:none'
@@ -47,9 +43,19 @@ jobs:
       - name: Determine version string
         id: version-string
         run: |
-          TAG="$(git describe --tags --exact-match --match "v*")"
-          VERSION="$(git describe --tags --match "v*" --abbrev=7
-          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'%Y%m%d.%H%M%S')"
+          # Get the SHA of the actual commit (not the fake merge commit) on PR-triggered runs
+          # (refer to https://stackoverflow.com/a/68068674/23202949):
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            ACTUAL_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # Note: we want to have a SHA to check out even in merge queues, so we always fall back
+            # to a SHA even if it's a fictional SHA detached from any branches:
+            ACTUAL_SHA="${{ github.sha }}"
+          fi
+
+          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA" || printf "")"
+          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA)"
+          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'td%Y%m%d-td%H%M%S' "$ACTUAL_SHA")"
 
           if [[ "$VERSION" != "$TAG" ]]; then
             VERSION="$VERSION-$TIMESTAMP"

--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -53,9 +53,9 @@ jobs:
             ACTUAL_SHA="${{ github.sha }}"
           fi
 
-          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA" || printf "")"
+          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA" 2>/dev/null || printf "")"
           VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA")"
-          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'td%Y%m%d-td%H%M%S' "$ACTUAL_SHA")"
+          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'t%Y%m%d%H%M%S' "$ACTUAL_SHA")"
 
           if [[ "$VERSION" != "$TAG" ]]; then
             VERSION="$VERSION-$TIMESTAMP"

--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -68,6 +68,12 @@ jobs:
           echo "version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Record version
+        run: |
+          VERSION="${{ steps.version-string.outputs.version }}"
+          echo "export const APP_VERSION = \"$VERSION\";" > ./frontend/src/version.js
+          cat ./frontend/src/version.js
+
       - name: Build
         working-directory: ./frontend
         run: |

--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -54,7 +54,7 @@ jobs:
           fi
 
           TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA" || printf "")"
-          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA)"
+          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA")"
           TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'td%Y%m%d-td%H%M%S' "$ACTUAL_SHA")"
 
           if [[ "$VERSION" != "$TAG" ]]; then

--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -25,6 +25,9 @@ jobs:
           # This repo has tons of cruft in its history, so we try to only fetch files we actually need:
           fetch-depth: 0
           filter: 'blob:none'
+          # We fetch tags so that the staged pallet bundle has a record of ancestral tags, for
+          # pseudoversion string generation:
+          fetch-tags: true
 
       - name: Use cached ~/.npm
         uses: actions/cache@v4
@@ -36,6 +39,34 @@ jobs:
       - name: Install build dependencies
         working-directory: ./frontend
         run: npm install
+
+      - name: Determine version string
+        id: version-string
+        run: |
+          # Get the SHA of the actual commit (not the fake merge commit) on PR-triggered runs
+          # (refer to https://stackoverflow.com/a/68068674/23202949):
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            ACTUAL_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # Note: we want to have a SHA to check out even in merge queues, so we always fall back
+            # to a SHA even if it's a fictional SHA detached from any branches:
+            ACTUAL_SHA="${{ github.sha }}"
+          fi
+
+          TAG="$(git describe --tags --exact-match --match "v*" "$ACTUAL_SHA")"
+          VERSION="$(git describe --tags --match "v*" --abbrev=7 "$ACTUAL_SHA)"
+          TIMESTAMP="$(TZ=UTC git show -s --format=%ad --date=format:'%Y%m%d.%H%M%S' "$ACTUAL_SHA")"
+
+          if [[ "$VERSION" != "$TAG" ]]; then
+            VERSION="$VERSION-$TIMESTAMP"
+            if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
+              # We're in a pull request
+              VERSION="$VERSION-pr${{ github.event.pull_request.number }}"
+            fi
+          fi
+
+          echo "version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build
         working-directory: ./frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ENV GENICAM_GENTL64_PATH="/opt/VimbaX/cti"
 
 # Larger slowly-changing dependencies are installed in a separate container image layer before the
 # rapidly-changing ImSwitch repository:
-RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/build-imswitch-deps.sh --mount=type=bind,source=./pyproject.toml,target=/mnt/ImSwitch/pyproject.toml --mount=type=bind,source=./uv.lock,target=/mnt/ImSwitch/uv.lock --mount=type=bind,source=./.git,target=/mnt/ImSwitch/.git /mnt/build/build-imswitch-deps.sh
+RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/build-imswitch-deps.sh --mount=type=bind,source=./pyproject.toml,target=/mnt/ImSwitch/pyproject.toml --mount=type=bind,source=./uv.lock,target=/mnt/ImSwitch/uv.lock /mnt/build/build-imswitch-deps.sh
 
 # Always pull the latest version of ImSwitch and UC2-REST repositories
 # Question(ethanjli): if we're copying the ImSwitch & UC2-REST repositories from local files using
@@ -87,7 +87,7 @@ RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/bui
 # this BUILD_DATE hack?
 # Adding a dynamic build argument to prevent caching
 ARG BUILD_DATE
-RUN --mount=type=bind,source=docker/build-imswitch.sh,target=/mnt/build/build-imswitch.sh --mount=type=bind,source=.,target=/mnt/ImSwitch --mount=type=bind,source=./.git,target=/mnt/ImSwitch/.git /mnt/build/build-imswitch.sh
+RUN --mount=type=bind,source=docker/build-imswitch.sh,target=/mnt/build/build-imswitch.sh --mount=type=bind,source=.,target=/mnt/ImSwitch /mnt/build/build-imswitch.sh
 # Expose HTTP port and Jupyter server port
 EXPOSE 8001 8888 8889
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ENV GENICAM_GENTL64_PATH="/opt/VimbaX/cti"
 
 # Larger slowly-changing dependencies are installed in a separate container image layer before the
 # rapidly-changing ImSwitch repository:
-RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/build-imswitch-deps.sh --mount=type=bind,source=./pyproject.toml,target=/mnt/ImSwitch/pyproject.toml --mount=type=bind,source=./uv.lock,target=/mnt/ImSwitch/uv.lock /mnt/build/build-imswitch-deps.sh
+RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/build-imswitch-deps.sh --mount=type=bind,source=./pyproject.toml,target=/mnt/ImSwitch/pyproject.toml --mount=type=bind,source=./uv.lock,target=/mnt/ImSwitch/uv.lock --mount=source=.git,target=.git,type=bind /mnt/build/build-imswitch-deps.sh
 
 # Always pull the latest version of ImSwitch and UC2-REST repositories
 # Question(ethanjli): if we're copying the ImSwitch & UC2-REST repositories from local files using
@@ -87,7 +87,7 @@ RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/bui
 # this BUILD_DATE hack?
 # Adding a dynamic build argument to prevent caching
 ARG BUILD_DATE
-RUN --mount=type=bind,source=docker/build-imswitch.sh,target=/mnt/build/build-imswitch.sh --mount=type=bind,source=.,target=/mnt/ImSwitch /mnt/build/build-imswitch.sh
+RUN --mount=type=bind,source=docker/build-imswitch.sh,target=/mnt/build/build-imswitch.sh --mount=type=bind,source=.,target=/mnt/ImSwitch --mount=source=.git,target=.git,type=bind /mnt/build/build-imswitch.sh
 # Expose HTTP port and Jupyter server port
 EXPOSE 8001 8888 8889
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ENV GENICAM_GENTL64_PATH="/opt/VimbaX/cti"
 
 # Larger slowly-changing dependencies are installed in a separate container image layer before the
 # rapidly-changing ImSwitch repository:
-RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/build-imswitch-deps.sh --mount=type=bind,source=./pyproject.toml,target=/mnt/ImSwitch/pyproject.toml --mount=type=bind,source=./uv.lock,target=/mnt/ImSwitch/uv.lock --mount=source=.git,target=.git,type=bind /mnt/build/build-imswitch-deps.sh
+RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/build-imswitch-deps.sh --mount=type=bind,source=./pyproject.toml,target=/mnt/ImSwitch/pyproject.toml --mount=type=bind,source=./uv.lock,target=/mnt/ImSwitch/uv.lock --mount=type=bind,source=./.git,target=/mnt/ImSwitch/.git /mnt/build/build-imswitch-deps.sh
 
 # Always pull the latest version of ImSwitch and UC2-REST repositories
 # Question(ethanjli): if we're copying the ImSwitch & UC2-REST repositories from local files using
@@ -87,7 +87,7 @@ RUN --mount=type=bind,source=docker/build-imswitch-deps.sh,target=/mnt/build/bui
 # this BUILD_DATE hack?
 # Adding a dynamic build argument to prevent caching
 ARG BUILD_DATE
-RUN --mount=type=bind,source=docker/build-imswitch.sh,target=/mnt/build/build-imswitch.sh --mount=type=bind,source=.,target=/mnt/ImSwitch --mount=source=.git,target=.git,type=bind /mnt/build/build-imswitch.sh
+RUN --mount=type=bind,source=docker/build-imswitch.sh,target=/mnt/build/build-imswitch.sh --mount=type=bind,source=.,target=/mnt/ImSwitch --mount=type=bind,source=./.git,target=/mnt/ImSwitch/.git /mnt/build/build-imswitch.sh
 # Expose HTTP port and Jupyter server port
 EXPOSE 8001 8888 8889
 

--- a/docker/build-imswitch-deps.sh
+++ b/docker/build-imswitch-deps.sh
@@ -30,10 +30,6 @@ export PATH="/root/.local/bin:$PATH"
 # slow-changing dependencies without installing ImSwitch itself yet.
 # This creates a separately-cached Docker image layer from the rapidly-changing source.
 mkdir -p /opt/imswitch/imswitch
-cat >/opt/imswitch/imswitch/__init__.py <<EOF
-# temporary placeholder to be overwritten by build-imswitch.sh
-__version__ = "0.0.0"
-EOF
 cp /mnt/ImSwitch/pyproject.toml /opt/imswitch/pyproject.toml
 cp /mnt/ImSwitch/uv.lock /opt/imswitch/uv.lock
 cd /opt/imswitch
@@ -41,10 +37,10 @@ cd /opt/imswitch
 # Install all deps from the lockfile without installing ImSwitch itself.
 # Using --frozen ensures the lockfile is used as-is (no resolver conflicts).
 # The venv was already created by build-uv.sh so we don't pass --python here.
-uv sync --no-install-project --frozen
+SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0" uv sync --no-install-project --frozen
 
 # Reinstall psygnal from source to work around binary-wheel ABI issues
-uv pip install psygnal --no-binary :all:
+SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0" uv pip install psygnal --no-binary :all:
 
 # Clean up build-only tools
 

--- a/docker/build-imswitch-deps.sh
+++ b/docker/build-imswitch-deps.sh
@@ -37,10 +37,10 @@ cd /opt/imswitch
 # Install all deps from the lockfile without installing ImSwitch itself.
 # Using --frozen ensures the lockfile is used as-is (no resolver conflicts).
 # The venv was already created by build-uv.sh so we don't pass --python here.
-SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0" uv sync --no-install-project --frozen
+uv sync --no-install-project --frozen
 
 # Reinstall psygnal from source to work around binary-wheel ABI issues
-SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0" uv pip install psygnal --no-binary :all:
+uv pip install psygnal --no-binary :all:
 
 # Clean up build-only tools
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "microscope-app",
-  "version": "1.6.6",
+  "name": "imswitch-frontend",
   "private": true,
   "homepage": "/imswitch/ui",
   "dependencies": {

--- a/frontend/src/version.js
+++ b/frontend/src/version.js
@@ -1,5 +1,4 @@
-/**
- * Application version - manually synchronized with package.json
- * Update this when bumping version in package.json
- */
-export const APP_VERSION = "1.6.6";
+// Note: for builds, the contents of this file are automatically replaced in GitHub Actions
+// with something like:
+// export const APP_VERSION = "v1.6.6";
+export const APP_VERSION = "development";

--- a/frontend/src/version.js
+++ b/frontend/src/version.js
@@ -1,4 +1,4 @@
 // Note: for builds, the contents of this file are automatically replaced in GitHub Actions
 // with something like:
 // export const APP_VERSION = "v1.6.6";
-export const APP_VERSION = "development";
+export const APP_VERSION = "v0.0.0-dev";

--- a/imswitch/__init__.py
+++ b/imswitch/__init__.py
@@ -9,10 +9,10 @@ if "pytest" in sys.modules or any("pytest" in arg for arg in sys.argv):
 
 # Import the new configuration system
 from .config import get_config
-from .version import version
+from . import version
 
 # used to be, but actions will replace this with the current release TAG -> >2.1.0
-__version__ = version
+__version__ = version.version
 __httpport__ = 8001
 __ssl__ = True
 __jupyter_port__ = 8888

--- a/imswitch/__init__.py
+++ b/imswitch/__init__.py
@@ -9,10 +9,10 @@ if "pytest" in sys.modules or any("pytest" in arg for arg in sys.argv):
 
 # Import the new configuration system
 from .config import get_config
-from . import version
+from .version import version
 
 # used to be, but actions will replace this with the current release TAG -> >2.1.0
-__version__ = version.version
+__version__ = version
 __httpport__ = 8001
 __ssl__ = True
 __jupyter_port__ = 8888

--- a/imswitch/__init__.py
+++ b/imswitch/__init__.py
@@ -1,6 +1,7 @@
 # Install test mocks for missing dependencies when running tests
 import sys
-if 'pytest' in sys.modules or any('pytest' in arg for arg in sys.argv):
+
+if "pytest" in sys.modules or any("pytest" in arg for arg in sys.argv):
     try:
         from . import _test_mocks
     except ImportError:
@@ -8,23 +9,24 @@ if 'pytest' in sys.modules or any('pytest' in arg for arg in sys.argv):
 
 # Import the new configuration system
 from .config import get_config
+from .version import version
 
 # used to be, but actions will replace this with the current release TAG -> >2.1.0
-__version__ = "2.1.193"
+__version__ = version
 __httpport__ = 8001
 __ssl__ = True
 __jupyter_port__ = 8888
 __argparse__ = None
 __available_controllers__ = []
 
-'''
+"""
 These are LEGACY flags for backward compatibility.
 New code should use the configuration system: from imswitch.config import get_config
-'''
+"""
 DEFAULT_SETUP_FILE = None
 DEFAULT_CONFIG_PATH = None
 DEFAULT_DATA_PATH = None
-SOCKET_STREAM = True           # Stream Images via socket ?
+SOCKET_STREAM = True  # Stream Images via socket ?
 SCAN_EXT_DATA_PATH = False  # Scan external data folder for new data ?
 EXT_DATA_PATH = None
 WITH_KERNEL = False  # Start with embedded Jupyter kernel

--- a/imswitch/version.py
+++ b/imswitch/version.py
@@ -1,4 +1,4 @@
 # Note: for builds, the contents of this file are automatically replaced in GitHub Actions
 # with something like:
 # version = "v2.1.193"
-version = "development"
+version = "v0.0.0-dev"

--- a/imswitch/version.py
+++ b/imswitch/version.py
@@ -1,0 +1,4 @@
+# Note: for builds, the contents of this file are automatically replaced in GitHub Actions
+# with something like:
+# version = "v2.1.193"
+version = "development"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,88 +1,109 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools-scm[simple]>=9.2", "wheel"]
+requires = [
+    "setuptools>=42",
+    "setuptools-scm[simple]>=9.2",
+    "wheel"
+]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "ImSwitchUC2"
 description = "Microscopy control"
 readme = "README.md"
-license = { text = "GPL-3.0-or-later" }
+license = {text = "GPL-3.0-or-later"}
 authors = [
-  { name = "Benedict Diederich", email = "benedictdied@gmail.com" },
-  { name = "Xavier Casas Moreno" },
+    {name = "Benedict Diederich", email = "benedictdied@gmail.com"},
+    {name = "Xavier Casas Moreno"},
 ]
 maintainers = [
-  { name = "Benedict Diederich", email = "benedictdied@gmail.com" },
+    {name = "Benedict Diederich", email = "benedictdied@gmail.com"},
 ]
 classifiers = [
-  "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-  "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Operating System :: OS Independent",
 ]
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
-  "setuptools >= 42",
-  "pydantic==2.11.4",
-  "coloredlogs >= 15",
-  "colour-science >= 0.3",
-  "dataclasses-json >= 0.5",
-  "h5py >= 2.10",
-  "pyvisa-py==0.4.1",
-  "lantzdev >= 0.5.2",
-  "luddite >= 1",
-  "nidaqmx >= 0.5.7",
-  "numpy==2.1.2",
-  "packaging >= 19",
-  "psutil >= 5.4.8",
-  "pyserial >= 3.4",
-  "requests >= 2.25",
-  "scikit-image==0.25.2",
-  "Send2Trash >= 1.8",
-  "tifffile >= 2020.11.26",
-  "dask[complete] >= 2024.8.0",
-  "fastapi >= 0.86.0",
-  "uvicorn[standard] >= 0.19.0",
-  "matplotlib == 3.9.2",
-  "opencv-python-headless",
-  "aiortc >= 1.9.0",
-  "jupyter",
-  "python-multipart >= 0.0.5",
-  "piexif >= 1.1.3",
-  "NanoImagingPack==2.1.5",
-  # Pin below 0.1.7: that PyPI release added imswitchuc2 as a dep, creating a
-  # circular dependency and an av==17 conflict with our aiortc-compatible av==13.
-  "imswitchclient>=0.1.2",
-  "psygnal",
-  "python-socketio[asyncio]==5.11.4",
-  "jupyterlab==4.2.5",
-  "python-dateutil >= 2.8.1",
-  "zarr>=3.0.0a0",
-  "numcodecs>=0.13.1",
-  "jsonschema>=4.0",
-  "aiohttp>=3.9.4",
-  "arkitekt-next[all]==0.40.3",
-  "koil>=2.0.5",
-  "msgpack>=1.0.4",
-  "esptool",
-  "av==13.1.0",
-  "uc2-rest>=0.2.0.33",
-  "unitelabs-sila",
-  "unitelabs-cdk",
-  "mikro-next>=1",
-  "pip>=26.1",
-  "opencv-contrib-python-headless>=4.13.0.92",
-  "opencv-contrib-python>=4.13.0.92",
-  "opencv-python>=4.13.0.92",
+    "setuptools >= 42",
+    "pydantic==2.11.4",
+    "coloredlogs >= 15",
+    "colour-science >= 0.3",
+    "dataclasses-json >= 0.5",
+    "h5py >= 2.10",
+    "pyvisa-py==0.4.1",
+    "lantzdev >= 0.5.2",
+    "luddite >= 1",
+    "nidaqmx >= 0.5.7",
+    "numpy==2.1.2",
+    "packaging >= 19",
+    "psutil >= 5.4.8",
+    "pyserial >= 3.4",
+    "requests >= 2.25",
+    "scikit-image==0.25.2",
+    "Send2Trash >= 1.8",
+    "tifffile >= 2020.11.26",
+    "dask[complete] >= 2024.8.0",
+    "fastapi >= 0.86.0",
+    "uvicorn[standard] >= 0.19.0",
+    "matplotlib == 3.9.2",
+    "opencv-python-headless",
+    "aiortc >= 1.9.0",
+    "jupyter",
+    "python-multipart >= 0.0.5",
+    "piexif >= 1.1.3",
+    "NanoImagingPack==2.1.5",
+    # Pin below 0.1.7: that PyPI release added imswitchuc2 as a dep, creating a
+    # circular dependency and an av==17 conflict with our aiortc-compatible av==13.
+    "imswitchclient>=0.1.2",
+    "psygnal",
+    "python-socketio[asyncio]==5.11.4",
+    "jupyterlab==4.2.5",
+    "python-dateutil >= 2.8.1",
+    "zarr>=3.0.0a0",
+    "numcodecs>=0.13.1",
+    "jsonschema>=4.0",
+    "aiohttp>=3.9.4",
+    "arkitekt-next[all]==0.40.3",
+    "koil>=2.0.5",
+    "msgpack>=1.0.4",
+    "esptool",
+    "av==13.1.0",
+    "uc2-rest>=0.2.0.33",
+    "unitelabs-sila",
+    "unitelabs-cdk",
+    "mikro-next>=1",
+    "pip>=26.1",
+    "opencv-contrib-python-headless>=4.13.0.92",
+    "opencv-contrib-python>=4.13.0.92",
+    "opencv-python>=4.13.0.92",
 ]
 
 [project.optional-dependencies]
-Microeye = ["numba>=0.61.2"]
-Lepmon = ["smbus2", "smbus", "RPi.GPIO", "luma.oled"]
-Ashlar = ["ashlarUC2"]
-imjoy = ["imjoy-rpc==0.5.59", "imjoy_rpc", "imjoy"]
-dev = ["pytest"]
-omero = ["omero-py >= 5.6.0"]
+Microeye = [
+    "numba>=0.61.2",
+]
+Lepmon = [
+    "smbus2",
+    "smbus",
+    "RPi.GPIO",
+    "luma.oled",
+]
+Ashlar = [
+    "ashlarUC2",
+]
+imjoy = [
+    "imjoy-rpc==0.5.59",
+    "imjoy_rpc",
+    "imjoy",
+]
+dev = [
+    "pytest",
+]
+omero = [
+    "omero-py >= 5.6.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/openuc2/ImSwitch"
@@ -118,10 +139,10 @@ no-binary-package = ["psygnal"]
 [tool.ruff]
 # Exclude directories
 exclude = [
-  "imswitch/_data",
-  "build",
-  "ImTools",
-  "imswitch/imcontrol/model/interfaces/pyicic",
+    "imswitch/_data",
+    "build",
+    "ImTools",
+    "imswitch/imcontrol/model/interfaces/pyicic",
 ]
 # Line length configuration (matching flake8's max-line-length)
 line-length = 100
@@ -135,7 +156,7 @@ line-length = 100
 select = ["E", "F", "W", "C90"]
 
 # Ignore F401 (unused imports) in __init__.py files (matching flake8 per-file-ignores)
-per-file-ignores = { "__init__.py" = ["F401"] }
+per-file-ignores = {"__init__.py" = ["F401"]}
 
 [tool.ruff.lint.mccabe]
 # Maximum McCabe complexity (matching flake8's max-complexity)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
+    "setuptools-scm[simple]>=9.2",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,109 +1,88 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "setuptools-scm[simple]>=9.2",
-    "wheel"
-]
+requires = ["setuptools>=42", "setuptools-scm[simple]>=9.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "ImSwitchUC2"
 description = "Microscopy control"
 readme = "README.md"
-license = {text = "GPL-3.0-or-later"}
+license = { text = "GPL-3.0-or-later" }
 authors = [
-    {name = "Benedict Diederich", email = "benedictdied@gmail.com"},
-    {name = "Xavier Casas Moreno"},
+  { name = "Benedict Diederich", email = "benedictdied@gmail.com" },
+  { name = "Xavier Casas Moreno" },
 ]
 maintainers = [
-    {name = "Benedict Diederich", email = "benedictdied@gmail.com"},
+  { name = "Benedict Diederich", email = "benedictdied@gmail.com" },
 ]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-    "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+  "Operating System :: OS Independent",
 ]
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
-    "setuptools >= 42",
-    "pydantic==2.11.4",
-    "coloredlogs >= 15",
-    "colour-science >= 0.3",
-    "dataclasses-json >= 0.5",
-    "h5py >= 2.10",
-    "pyvisa-py==0.4.1",
-    "lantzdev >= 0.5.2",
-    "luddite >= 1",
-    "nidaqmx >= 0.5.7",
-    "numpy==2.1.2",
-    "packaging >= 19",
-    "psutil >= 5.4.8",
-    "pyserial >= 3.4",
-    "requests >= 2.25",
-    "scikit-image==0.25.2",
-    "Send2Trash >= 1.8",
-    "tifffile >= 2020.11.26",
-    "dask[complete] >= 2024.8.0",
-    "fastapi >= 0.86.0",
-    "uvicorn[standard] >= 0.19.0",
-    "matplotlib == 3.9.2",
-    "opencv-python-headless",
-    "aiortc >= 1.9.0",
-    "jupyter",
-    "python-multipart >= 0.0.5",
-    "piexif >= 1.1.3",
-    "NanoImagingPack==2.1.5",
-    # Pin below 0.1.7: that PyPI release added imswitchuc2 as a dep, creating a
-    # circular dependency and an av==17 conflict with our aiortc-compatible av==13.
-    "imswitchclient>=0.1.2",
-    "psygnal",
-    "python-socketio[asyncio]==5.11.4",
-    "jupyterlab==4.2.5",
-    "python-dateutil >= 2.8.1",
-    "zarr>=3.0.0a0",
-    "numcodecs>=0.13.1",
-    "jsonschema>=4.0",
-    "aiohttp>=3.9.4",
-    "arkitekt-next[all]==0.40.3",
-    "koil>=2.0.5",
-    "msgpack>=1.0.4",
-    "esptool",
-    "av==13.1.0",
-    "uc2-rest>=0.2.0.33",
-    "unitelabs-sila",
-    "unitelabs-cdk",
-    "mikro-next>=1",
-    "pip>=26.1",
-    "opencv-contrib-python-headless>=4.13.0.92",
-    "opencv-contrib-python>=4.13.0.92",
-    "opencv-python>=4.13.0.92",
+  "setuptools >= 42",
+  "pydantic==2.11.4",
+  "coloredlogs >= 15",
+  "colour-science >= 0.3",
+  "dataclasses-json >= 0.5",
+  "h5py >= 2.10",
+  "pyvisa-py==0.4.1",
+  "lantzdev >= 0.5.2",
+  "luddite >= 1",
+  "nidaqmx >= 0.5.7",
+  "numpy==2.1.2",
+  "packaging >= 19",
+  "psutil >= 5.4.8",
+  "pyserial >= 3.4",
+  "requests >= 2.25",
+  "scikit-image==0.25.2",
+  "Send2Trash >= 1.8",
+  "tifffile >= 2020.11.26",
+  "dask[complete] >= 2024.8.0",
+  "fastapi >= 0.86.0",
+  "uvicorn[standard] >= 0.19.0",
+  "matplotlib == 3.9.2",
+  "opencv-python-headless",
+  "aiortc >= 1.9.0",
+  "jupyter",
+  "python-multipart >= 0.0.5",
+  "piexif >= 1.1.3",
+  "NanoImagingPack==2.1.5",
+  # Pin below 0.1.7: that PyPI release added imswitchuc2 as a dep, creating a
+  # circular dependency and an av==17 conflict with our aiortc-compatible av==13.
+  "imswitchclient>=0.1.2",
+  "psygnal",
+  "python-socketio[asyncio]==5.11.4",
+  "jupyterlab==4.2.5",
+  "python-dateutil >= 2.8.1",
+  "zarr>=3.0.0a0",
+  "numcodecs>=0.13.1",
+  "jsonschema>=4.0",
+  "aiohttp>=3.9.4",
+  "arkitekt-next[all]==0.40.3",
+  "koil>=2.0.5",
+  "msgpack>=1.0.4",
+  "esptool",
+  "av==13.1.0",
+  "uc2-rest>=0.2.0.33",
+  "unitelabs-sila",
+  "unitelabs-cdk",
+  "mikro-next>=1",
+  "pip>=26.1",
+  "opencv-contrib-python-headless>=4.13.0.92",
+  "opencv-contrib-python>=4.13.0.92",
+  "opencv-python>=4.13.0.92",
 ]
 
 [project.optional-dependencies]
-Microeye = [
-    "numba>=0.61.2",
-]
-Lepmon = [
-    "smbus2",
-    "smbus",
-    "RPi.GPIO",
-    "luma.oled",
-]
-Ashlar = [
-    "ashlarUC2",
-]
-imjoy = [
-    "imjoy-rpc==0.5.59",
-    "imjoy_rpc",
-    "imjoy",
-]
-dev = [
-    "pytest",
-]
-omero = [
-    "omero-py >= 5.6.0",
-]
+Microeye = ["numba>=0.61.2"]
+Lepmon = ["smbus2", "smbus", "RPi.GPIO", "luma.oled"]
+Ashlar = ["ashlarUC2"]
+imjoy = ["imjoy-rpc==0.5.59", "imjoy_rpc", "imjoy"]
+dev = ["pytest"]
+omero = ["omero-py >= 5.6.0"]
 
 [project.urls]
 Homepage = "https://github.com/openuc2/ImSwitch"
@@ -119,7 +98,7 @@ include = ["imswitch*"]
 "*" = ["*"]
 
 [tool.setuptools_scm]
-fallback_version = "0.0.0"
+fallback_version = "0.0.0.dev0"
 
 [project.entry-points."imswitch.implugins.detectors"]
 
@@ -139,10 +118,10 @@ no-binary-package = ["psygnal"]
 [tool.ruff]
 # Exclude directories
 exclude = [
-    "imswitch/_data",
-    "build",
-    "ImTools",
-    "imswitch/imcontrol/model/interfaces/pyicic",
+  "imswitch/_data",
+  "build",
+  "ImTools",
+  "imswitch/imcontrol/model/interfaces/pyicic",
 ]
 # Line length configuration (matching flake8's max-line-length)
 line-length = 100
@@ -156,7 +135,7 @@ line-length = 100
 select = ["E", "F", "W", "C90"]
 
 # Ignore F401 (unused imports) in __init__.py files (matching flake8 per-file-ignores)
-per-file-ignores = {"__init__.py" = ["F401"]}
+per-file-ignores = { "__init__.py" = ["F401"] }
 
 [tool.ruff.lint.mccabe]
 # Maximum McCabe complexity (matching flake8's max-complexity)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,9 @@ include = ["imswitch*"]
 [tool.setuptools.package-data]
 "*" = ["*"]
 
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+
 [project.entry-points."imswitch.implugins.detectors"]
 
 [project.entry-points."imswitch.implugins.lasers"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,6 @@ Homepage = "https://github.com/openuc2/ImSwitch"
 [project.scripts]
 imswitch = "imswitch.__main__:main"
 
-[tool.setuptools.dynamic]
-version = {attr = "imswitch.__version__"}
-
 [tool.setuptools.packages.find]
 include = ["imswitch*"]
 

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,6 @@
 from setuptools import setup, find_packages
 
 
-# Version will be read from your package's __init__.py
-# Make sure __version__ is defined in imswitch/__init__.py
-def get_version():
-    version_file = 'imswitch/__init__.py'
-    with open(version_file, 'r') as file:
-        for line in file:
-            if line.startswith('__version__'):
-                # Strip the line to remove whitespaces and newline characters,
-                # then split it on '=' and strip again to remove any remaining whitespaces.
-                # Finally, strip the quotes from the version string.
-                return line.strip().split('=')[1].strip().strip('\'"')
-    raise RuntimeError('Unable to find version string.')
-
-
 # NOTE: This setup.py is maintained for backward compatibility.
 # The primary configuration is now in pyproject.toml for UV support.
 # When using UV, this file is not needed, but it's kept for pip compatibility.
@@ -25,7 +11,6 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="ImSwitchUC2",
-    version=get_version(),
     author="Benedict Diederich, Xavier Casas Moreno, et al.",
     author_email="benedictdied@gmail.com",
     description="Microscopy control",


### PR DESCRIPTION
This PR automatically sets the backend and frontend's version strings from VCS information available during the build CI workflows, in order to remove the need to manually/automatically create VCS commits for updating version strings after changes are made.

The version strings produced by this PR do not follow the pseudoversion format used in Go Modules or Forklift; instead, they look something like "v2.1.192-89-g930ffbe-t20260523153301-pr278" for PR commits and something like "v2.1.192-89-g930ffbe-t20260523153301" for non-PR commits. For builds of pushed tags, they should look like "v2.2.0" (but that functionality is not yet tested).

This work is tracked on Notion at https://www.notion.so/Bake-VCS-info-into-the-ImSwitch-container-image-3574e612c78a8053929ce57897eee6c7?source=copy_link