### PR TITLE
Fix/blacklevel synchronisation

### DIFF
--- a/frontend/src/components/DetectorParameters.js
+++ b/frontend/src/components/DetectorParameters.js
@@ -11,7 +11,6 @@ import {
   FormControl,
   InputLabel,
   Select,
-  Alert,
 } from "@mui/material";
 import { Camera, InfoOutlined } from "@mui/icons-material";
 import * as detectorParametersSlice from "../state/slices/DetectorParametersSlice.js";
@@ -208,8 +207,23 @@ export default function DetectorParameters({ hostIP, hostPort }) {
 
   const handleNumericFieldChange = (field, setValue) => (e) => {
     beginEditing(field);
-    setValue(e.target.value);
-    handleImmediateFieldChange(field, e.target.value);
+    const raw = e.target.value;
+    if (field === "blacklevel") {
+      // Keep empty string while typing, but prevent committing negative values.
+      if (raw === "") {
+        setValue(raw);
+        return;
+      }
+      const num = Number(raw);
+      if (!isNaN(num)) {
+        const clamped = Math.max(0, num);
+        setValue(String(clamped));
+        handleImmediateFieldChange(field, clamped);
+        return;
+      }
+    }
+    setValue(raw);
+    handleImmediateFieldChange(field, raw);
   };
 
   const handleNumericFieldKeyDown = (e) => {
@@ -473,7 +487,7 @@ export default function DetectorParameters({ hostIP, hostPort }) {
                     sx={{ p: 0, height: 18 }}
                     aria-label="Decrement black level"
                     onClick={() => {
-                      const next = Number(localBlacklevel || 0) - 1;
+                      const next = Math.max(0, Number(localBlacklevel || 0) - 1);
                       setLocalBlacklevel(String(next));
                       handleImmediateFieldChange("blacklevel", next);
                     }}

--- a/frontend/src/components/DetectorParameters.js
+++ b/frontend/src/components/DetectorParameters.js
@@ -487,7 +487,10 @@ export default function DetectorParameters({ hostIP, hostPort }) {
                     sx={{ p: 0, height: 18 }}
                     aria-label="Decrement black level"
                     onClick={() => {
-                      const next = Math.max(0, Number(localBlacklevel || 0) - 1);
+                      const next = Math.max(
+                        0,
+                        Number(localBlacklevel || 0) - 1,
+                      );
                       setLocalBlacklevel(String(next));
                       handleImmediateFieldChange("blacklevel", next);
                     }}

--- a/frontend/src/components/DetectorParameters.js
+++ b/frontend/src/components/DetectorParameters.js
@@ -135,7 +135,7 @@ export default function DetectorParameters({ hostIP, hostPort }) {
             break;
           case "blacklevel":
             await fetch(
-              `${hostIP}:${hostPort}/imswitch/api/SettingsController/setDetectorBlackLevel?blacklevel=${value}`,
+              `${hostIP}:${hostPort}/imswitch/api/SettingsController/setDetectorBlackLevel?blackLevel=${value}`,
             );
             break;
           default:

--- a/frontend/src/components/StreamControlOverlay.js
+++ b/frontend/src/components/StreamControlOverlay.js
@@ -488,30 +488,28 @@ const StreamControlOverlay = ({
           </Box>
         ) : (
           <>
-            {!forceExpanded && (
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  mb: 1,
-                }}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                mb: 1,
+              }}
+            >
+              <Typography
+                variant="h6"
+                sx={{ fontWeight: "bold", fontSize: "1rem" }}
               >
-                <Typography
-                  variant="h6"
-                  sx={{ fontWeight: "bold", fontSize: "1rem" }}
-                >
-                  Stream Controls
-                </Typography>
-                <IconButton
-                  size="small"
-                  onClick={() => setIsExpanded(false)}
-                  sx={{ ml: "auto" }}
-                >
-                  <ExpandLessIcon />
-                </IconButton>
-              </Box>
-            )}
+                Stream Controls
+              </Typography>
+              <IconButton
+                size="small"
+                onClick={() => setIsExpanded(false)}
+                sx={{ ml: "auto" }}
+              >
+                <ExpandLessIcon />
+              </IconButton>
+            </Box>
 
             <Box
               sx={{
@@ -569,7 +567,10 @@ const StreamControlOverlay = ({
             variant="fullWidth"
             sx={{ borderBottom: 1, borderColor: "divider", flexShrink: 0 }}
           >
-            <Tab label="Controls" />
+            <Tab
+              label="Display Range
+"
+            />
             <Tab label="Settings" />
             <Tab label="Info" />
           </Tabs>
@@ -677,13 +678,6 @@ const StreamControlOverlay = ({
             {/* Settings Tab */}
             {activeTab === 1 && (
               <Box sx={{ p: 2, pb: 0 }}>
-                <Typography
-                  variant="body2"
-                  sx={{ mb: 2, fontWeight: "medium" }}
-                >
-                  Stream Settings
-                </Typography>
-
                 {/* Crop Control - Shared across all formats */}
                 <Box sx={{ mb: 3 }}>
                   <Box
@@ -1153,8 +1147,8 @@ const StreamControlOverlay = ({
                     pt: 1,
                     pb: 1,
                     mt: 3,
-                    backgroundColor: theme.palette.background.paper,
-                    borderTop: `1px solid ${theme.palette.divider}`,
+                    backgroundColor: "transparent",
+                    borderTop: "none",
                     display: "flex",
                     gap: 1,
                     zIndex: 1,

--- a/frontend/src/components/StreamControlOverlay.js
+++ b/frontend/src/components/StreamControlOverlay.js
@@ -569,10 +569,7 @@ const StreamControlOverlay = ({
             variant="fullWidth"
             sx={{ borderBottom: 1, borderColor: "divider", flexShrink: 0 }}
           >
-            <Tab
-              label="Display Range
-"
-            />
+            <Tab label="Display Range" />
             <Tab label="Settings" />
             <Tab label="Info" />
           </Tabs>

--- a/frontend/src/components/StreamControlOverlay.js
+++ b/frontend/src/components/StreamControlOverlay.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   Box,
   Paper,
@@ -15,20 +15,16 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Switch,
-  FormControlLabel,
   Alert,
   CircularProgress,
   useTheme,
 } from "@mui/material";
 import {
-  ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
   AutoMode as AutoModeIcon,
   Settings as SettingsIcon,
   Save as SaveIcon,
   Refresh as RefreshIcon,
-  Info as InfoIcon,
 } from "@mui/icons-material";
 import { useSelector, useDispatch } from "react-redux";
 import {
@@ -43,6 +39,7 @@ import {
   updateDetectorSettings,
 } from "../state/slices/LiveStreamSlice.js";
 import { getLiveViewState } from "../state/slices/LiveViewSlice.js";
+import { setNotification } from "../state/slices/NotificationSlice.js";
 import apiLiveViewControllerSetStreamParameters from "../backendapi/apiLiveViewControllerSetStreamParameters";
 import apiLiveViewControllerGetStreamParameters from "../backendapi/apiLiveViewControllerGetStreamParameters";
 import apiLiveViewControllerSetDetectorStreamParameters from "../backendapi/apiLiveViewControllerSetDetectorStreamParameters";
@@ -66,7 +63,7 @@ const StreamControlOverlay = ({
   const [activeTab, setActiveTab] = useState(0); // 0 = Controls, 1 = Settings, 2 = Info
 
   const connectionSettingsState = useSelector(
-    connectionSettingsSlice.getConnectionSettingsState
+    connectionSettingsSlice.getConnectionSettingsState,
   );
   const liveViewState = useSelector(getLiveViewState);
 
@@ -82,11 +79,9 @@ const StreamControlOverlay = ({
   // Draft mode for settings - initialize from Redux streamSettings
   const [draftSettings, setDraftSettings] = useState({
     ...streamSettings,
-    crop_size: liveStreamState.cropSize || 0
+    crop_size: liveStreamState.cropSize || 0,
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState(null);
-  const [submitSuccess, setSubmitSuccess] = useState(false);
 
   // Determine if we're in JPEG mode
   const isJpeg = imageFormat === "jpeg";
@@ -102,6 +97,7 @@ const StreamControlOverlay = ({
       minVal,
       maxVal,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Get current frame ID from stats
@@ -155,7 +151,11 @@ const StreamControlOverlay = ({
         };
 
         // Add crop_size from backend response (shared across all protocols)
-        loadedSettings.crop_size = allParams.binary?.crop_size || allParams.jpeg?.crop_size || allParams.webrtc?.crop_size || 0;
+        loadedSettings.crop_size =
+          allParams.binary?.crop_size ||
+          allParams.jpeg?.crop_size ||
+          allParams.webrtc?.crop_size ||
+          0;
 
         setDraftSettings(loadedSettings);
 
@@ -164,7 +164,7 @@ const StreamControlOverlay = ({
         if (currentProtocol !== imageFormat) {
           console.log(
             "Backend protocol differs from persisted format, updating to:",
-            currentProtocol
+            currentProtocol,
           );
           dispatch(setImageFormat(currentProtocol));
 
@@ -189,6 +189,13 @@ const StreamControlOverlay = ({
         }
       } catch (error) {
         console.warn("Failed to load backend settings:", error);
+        dispatch(
+          setNotification({
+            message:
+              "Stream settings could not be loaded from backend. Using fallback values.",
+            type: "error",
+          }),
+        );
         // Use Redux state as fallback or set defaults to JPEG
         const fallbackSettings = streamSettings || {
           binary: {
@@ -245,8 +252,6 @@ const StreamControlOverlay = ({
   // Settings handlers
   const handleSubmitSettings = async () => {
     setIsSubmitting(true);
-    setSubmitError(null);
-    setSubmitSuccess(false);
 
     // Capture current Redux format BEFORE making any changes
     const previousFormat = liveStreamState.imageFormat || "binary";
@@ -258,14 +263,14 @@ const StreamControlOverlay = ({
       const newFormat = isWebRTCMode
         ? "webrtc"
         : isJpegMode
-        ? "jpeg"
-        : "binary";
+          ? "jpeg"
+          : "binary";
 
       console.log(
         "Submitting settings for format:",
         newFormat,
         "Draft settings:",
-        draftSettings
+        draftSettings,
       );
 
       // Submit to backend FIRST using new LiveViewController API
@@ -299,7 +304,7 @@ const StreamControlOverlay = ({
 
       console.log(
         "Stream parameters updated successfully for protocol:",
-        newFormat
+        newFormat,
       );
 
       // Check if format changed by comparing with previousFormat (captured at start of function)
@@ -312,7 +317,7 @@ const StreamControlOverlay = ({
       // Restart stream if format changed
       if (formatChanged) {
         console.log(
-          `Format changed from ${previousFormat} to ${newFormat}, restarting stream...`
+          `Format changed from ${previousFormat} to ${newFormat}, restarting stream...`,
         );
 
         // Stop current stream
@@ -368,47 +373,64 @@ const StreamControlOverlay = ({
               crop_size: draftSettings.crop_size || 0,
             }
           : isJpegMode
-          ? {
-              protocol: "jpeg",
-              jpeg_quality: draftSettings.jpeg?.quality || 85,
-              subsampling_factor: draftSettings.jpeg?.subsampling?.factor || 1,
-              throttle_ms: draftSettings.jpeg?.throttle_ms || 100,
-              crop_size: draftSettings.crop_size || 0,
-            }
-          : {
-              protocol: "binary",
-              compression_algorithm:
-                draftSettings.binary?.compression?.algorithm || "lz4",
-              compression_level: draftSettings.binary?.compression?.level || 0,
-              subsampling_factor:
-                draftSettings.binary?.subsampling?.factor || 4,
-              throttle_ms: draftSettings.binary?.throttle_ms || 100,
-              crop_size: draftSettings.crop_size || 0,
-            };
+            ? {
+                protocol: "jpeg",
+                jpeg_quality: draftSettings.jpeg?.quality || 85,
+                subsampling_factor:
+                  draftSettings.jpeg?.subsampling?.factor || 1,
+                throttle_ms: draftSettings.jpeg?.throttle_ms || 100,
+                crop_size: draftSettings.crop_size || 0,
+              }
+            : {
+                protocol: "binary",
+                compression_algorithm:
+                  draftSettings.binary?.compression?.algorithm || "lz4",
+                compression_level:
+                  draftSettings.binary?.compression?.level || 0,
+                subsampling_factor:
+                  draftSettings.binary?.subsampling?.factor || 4,
+                throttle_ms: draftSettings.binary?.throttle_ms || 100,
+                crop_size: draftSettings.crop_size || 0,
+              };
 
         dispatch(
           updateDetectorSettings({
             detectorName: activeDetectorName,
             settings: detectorParams,
-          })
+          }),
         );
 
         // Fire-and-forget to backend
         apiLiveViewControllerSetDetectorStreamParameters(
           activeDetectorName,
-          detectorParams
-        ).catch((err) =>
-          console.warn("Failed to save per-detector params:", err)
-        );
+          detectorParams,
+        ).catch((err) => {
+          console.warn("Failed to save per-detector params:", err);
+          dispatch(
+            setNotification({
+              message: "Failed to save per-detector stream settings.",
+              type: "error",
+            }),
+          );
+        });
       }
 
       fetchObjectiveControllerGetStatus(dispatch);
-
-      setSubmitSuccess(true);
-      setTimeout(() => setSubmitSuccess(false), 3000);
+      dispatch(
+        setNotification({
+          message: "Stream settings submitted successfully!",
+          type: "success",
+        }),
+      );
     } catch (error) {
       console.error("Error submitting stream settings:", error);
-      setSubmitError(error.message || "Failed to submit settings");
+      const errorMessage = error?.message || "Failed to submit settings";
+      dispatch(
+        setNotification({
+          message: `Stream settings submit failed: ${errorMessage}`,
+          type: "error",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -416,8 +438,6 @@ const StreamControlOverlay = ({
 
   const handleResetSettings = () => {
     setDraftSettings({});
-    setSubmitError(null);
-    setSubmitSuccess(false);
   };
 
   return (
@@ -437,7 +457,8 @@ const StreamControlOverlay = ({
         zIndex: forceExpanded ? "auto" : 1000,
         transition: forceExpanded ? "none" : "all 0.3s ease-in-out",
         cursor: isExpanded || forceExpanded ? "default" : "pointer",
-        overflow: forceExpanded ? "visible" : isExpanded ? "auto" : "hidden",
+        overflowX: "hidden",
+        overflowY: forceExpanded ? "visible" : isExpanded ? "auto" : "hidden",
         display: "flex",
         flexDirection: "column",
       }}
@@ -558,6 +579,7 @@ const StreamControlOverlay = ({
             sx={{
               flex: 1,
               minHeight: 0,
+              overflowX: "hidden",
               overflowY: "auto",
               "&::-webkit-scrollbar": { width: 6 },
               "&::-webkit-scrollbar-track": { backgroundColor: "transparent" },
@@ -678,7 +700,9 @@ const StreamControlOverlay = ({
                     <Button
                       size="small"
                       variant="outlined"
-                      onClick={() => setDraftSettings(prev => ({ ...prev, crop_size: 0 }))}
+                      onClick={() =>
+                        setDraftSettings((prev) => ({ ...prev, crop_size: 0 }))
+                      }
                       disabled={draftSettings.crop_size === 0}
                       sx={{ ml: "auto", fontSize: "0.75rem", py: 0.25 }}
                     >
@@ -688,15 +712,24 @@ const StreamControlOverlay = ({
 
                   <Box sx={{ mb: 1 }}>
                     <Typography variant="caption" color="textSecondary">
-                      Crop Size: {draftSettings.crop_size === 0 ? "Full FOV" : `${draftSettings.crop_size}px`}
+                      Crop Size:{" "}
+                      {draftSettings.crop_size === 0
+                        ? "Full FOV"
+                        : `${draftSettings.crop_size}px`}
                     </Typography>
                     <Slider
                       value={draftSettings.crop_size || 0}
                       onChange={(_, value) => {
-                        setDraftSettings(prev => ({ ...prev, crop_size: value }));
+                        setDraftSettings((prev) => ({
+                          ...prev,
+                          crop_size: value,
+                        }));
                       }}
                       min={0}
-                      max={Math.max(imageSize?.width || 2048, imageSize?.height || 2048)}
+                      max={Math.max(
+                        imageSize?.width || 2048,
+                        imageSize?.height || 2048,
+                      )}
                       step={16}
                       valueLabelDisplay="auto"
                       size="small"
@@ -706,7 +739,8 @@ const StreamControlOverlay = ({
                       color="textSecondary"
                       sx={{ display: "block", mt: 0.5, fontSize: "0.7rem" }}
                     >
-                      Crops quadratic region around center (applied before subsampling)
+                      Crops quadratic region around center (applied before
+                      subsampling)
                     </Typography>
                   </Box>
                 </Box>
@@ -720,8 +754,8 @@ const StreamControlOverlay = ({
                         draftSettings?.webrtc?.enabled
                           ? "webrtc"
                           : draftSettings?.jpeg?.enabled
-                          ? "jpeg"
-                          : "binary"
+                            ? "jpeg"
+                            : "binary"
                       }
                       label="Stream Format"
                       onChange={(e) => {
@@ -760,8 +794,8 @@ const StreamControlOverlay = ({
                     {draftSettings?.webrtc?.enabled
                       ? "WebRTC"
                       : draftSettings?.binary?.enabled
-                      ? "Binary"
-                      : "JPEG"}
+                        ? "Binary"
+                        : "JPEG"}
                   </Typography>
                 </Box>
 
@@ -1103,7 +1137,7 @@ const StreamControlOverlay = ({
                       >
                         Frame interval: ~
                         {Math.round(
-                          1000 / (draftSettings.webrtc?.throttle_ms || 33)
+                          1000 / (draftSettings.webrtc?.throttle_ms || 33),
                         )}{" "}
                         FPS
                       </Typography>
@@ -1145,26 +1179,6 @@ const StreamControlOverlay = ({
                     Reset
                   </Button>
                 </Box>
-
-                {submitError && (
-                  <Alert
-                    severity="error"
-                    sx={{ mt: 1 }}
-                    onClose={() => setSubmitError(null)}
-                  >
-                    {submitError}
-                  </Alert>
-                )}
-
-                {submitSuccess && (
-                  <Alert
-                    severity="success"
-                    sx={{ mt: 1 }}
-                    onClose={() => setSubmitSuccess(false)}
-                  >
-                    Settings submitted successfully!
-                  </Alert>
-                )}
               </Box>
             )}
 

--- a/frontend/src/components/StreamControlOverlay.js
+++ b/frontend/src/components/StreamControlOverlay.js
@@ -502,13 +502,15 @@ const StreamControlOverlay = ({
               >
                 Stream Controls
               </Typography>
-              <IconButton
-                size="small"
-                onClick={() => setIsExpanded(false)}
-                sx={{ ml: "auto" }}
-              >
-                <ExpandLessIcon />
-              </IconButton>
+              {!forceExpanded && (
+                <IconButton
+                  size="small"
+                  onClick={() => setIsExpanded(false)}
+                  sx={{ ml: "auto" }}
+                >
+                  <ExpandLessIcon />
+                </IconButton>
+              )}
             </Box>
 
             <Box

--- a/frontend/src/components/StreamControls.js
+++ b/frontend/src/components/StreamControls.js
@@ -11,7 +11,6 @@ import {
   Select,
   MenuItem,
   Dialog,
-  DialogTitle,
   DialogContent,
   Tooltip,
   Switch,
@@ -544,7 +543,6 @@ export default function StreamControls({
         maxWidth="md"
         fullWidth
       >
-        <DialogTitle>Stream Settings</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <StreamControlOverlay
             stats={hudData.stats}


### PR DESCRIPTION
This pull request improves robustness and user feedback for stream and detector parameter controls in the frontend, with a focus on error handling, input validation, and UI consistency. The main changes include better notification handling for backend errors, stricter validation for detector black level input, and several UI/UX refinements.

**Input validation and API correctness:**

* Improved validation for the `blacklevel` detector parameter: negative values are now prevented, and empty input is handled gracefully. Also corrected the API parameter name from `blacklevel` to `blackLevel` for backend compatibility. [[1]](diffhunk://#diff-25d76cc3b9cc2197b98a1b074830e1546d58a9e97c2bca8a6237a479c042e918L138-R137) [[2]](diffhunk://#diff-25d76cc3b9cc2197b98a1b074830e1546d58a9e97c2bca8a6237a479c042e918L211-R226) [[3]](diffhunk://#diff-25d76cc3b9cc2197b98a1b074830e1546d58a9e97c2bca8a6237a479c042e918L476-R493)

**UI/UX refinements:**

* Adjusted overflow handling and scrolling behavior for the stream control overlay for better layout consistency and usability. [[1]](diffhunk://#diff-064fb804a25591ddf485bad6b26f788038dbe818cd2580bcd028a228e5790cc4L440-R461) [[2]](diffhunk://#diff-064fb804a25591ddf485bad6b26f788038dbe818cd2580bcd028a228e5790cc4R583)
* Improved formatting and clarity of crop size controls and tab labels, including better handling of max values and label wrapping. [[1]](diffhunk://#diff-064fb804a25591ddf485bad6b26f788038dbe818cd2580bcd028a228e5790cc4L551-R573) [[2]](diffhunk://#diff-064fb804a25591ddf485bad6b26f788038dbe818cd2580bcd028a228e5790cc4L681-R699) [[3]](diffhunk://#diff-064fb804a25591ddf485bad6b26f788038dbe818cd2580bcd028a228e5790cc4L691-R726) [[4]](diffhunk://#diff-064fb804a25591ddf485bad6b26f788038dbe818cd2580bcd028a228e5790cc4L709-R737)
* Cleaned up imports by removing unused components and icons for maintainability. [[1]](diffhunk://#diff-25d76cc3b9cc2197b98a1b074830e1546d58a9e97c2bca8a6237a479c042e918L14) [[2]](diffhunk://#diff-064fb804a25591ddf485bad6b26f788038dbe818cd2580bcd028a228e5790cc4L1-R1) [[3]](diffhunk://#diff-064fb804a25591ddf485bad6b26f788038dbe818cd2580bcd028a228e5790cc4L18-L31)