### PR TITLE
Update command for removing useless DLLs from Docker ctr img

### DIFF
--- a/docker/build-imswitch.sh
+++ b/docker/build-imswitch.sh
@@ -18,15 +18,14 @@ uv sync --frozen
 # Note(ethanjli): we delete DLL files because they take up a significant amount of space, and
 # they should be useless in Linux anyways (as they're Windows-specific)
 shopt -s globstar
-ls /opt/imswitch/.venv/lib/*/site-packages/imswitch/**/*.dll 2>/dev/null || true
-rm -rf /opt/imswitch/.venv/lib/*/site-packages/imswitch/**/*.dll 2>/dev/null || true
+rm -rf /opt/imswitch/imswitch/**/*.dll 2>/dev/null || true
 
 # UC2-REST is installed from PyPI via the lockfile by uv sync above — no git clone needed.
 
 # Link system picamera2 and required modules to UV venv
 # This ensures that the UV venv Python uses the system's picamera2 with proper libcamera bindings
 UV_SITE_PACKAGES=$(/opt/imswitch/.venv/bin/python -c 'import site; print(site.getsitepackages()[0])')
-echo '/usr/lib/python3/dist-packages' > $UV_SITE_PACKAGES/system-packages.pth
+echo '/usr/lib/python3/dist-packages' >"$UV_SITE_PACKAGES"/system-packages.pth
 /opt/imswitch/.venv/bin/python -c 'import sys; print("Python paths:"); [print(p) for p in sys.path]'
 
 # Install simplejpeg in UV environment to avoid NumPy ABI compatibility issues


### PR DESCRIPTION
This PR follows up on #175 by updating the path (set in that PR) for deleting useless Windows-specific camera driver DLL files from the Docker container image, to match the changes made in https://github.com/openUC2/ImSwitch/commit/5c1638cabe58f894c965e537cf945d70e3faffd8 .

This fixes a ~80 MB regression in the size of the build-imswitch layer of the container image, which must be re-downloaded whenever any ImSwitch source files are changed.