### PR TITLE
Exclude JS source map files from Docker ctr img

### DIFF
--- a/.github/workflows/build-docker-server.yaml
+++ b/.github/workflows/build-docker-server.yaml
@@ -64,10 +64,6 @@ jobs:
           github-token: ${{github.token}}
           run-id: ${{ steps.wait-build-frontend.outputs.run-id }}
 
-      - name: Remove source map files from built frontend
-        run: |
-          rm ./frontend/build/static/*/*.map
-
       # Work around a bug where capital letters in the GitHub username (e.g. "PlanktoScope") make it
       # impossible to push to GHCR. See https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase image registry and owner

--- a/.github/workflows/build-docker-server.yaml
+++ b/.github/workflows/build-docker-server.yaml
@@ -64,6 +64,10 @@ jobs:
           github-token: ${{github.token}}
           run-id: ${{ steps.wait-build-frontend.outputs.run-id }}
 
+      - name: Remove source map files from built frontend
+        run: |
+          rm ./frontend/build/static/*/*.map
+
       # Work around a bug where capital letters in the GitHub username (e.g. "PlanktoScope") make it
       # impossible to push to GHCR. See https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase image registry and owner

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,7 @@
   },
   "scripts": {
     "start": "craco start",
-    "build": "craco build",
+    "build": "GENERATE_SOURCEMAP=false craco build",
     "test": "craco test"
   },
   "scripts_old": {


### PR DESCRIPTION
This PR shrinks the "build-imswitch" layer of the ImSwitch Docker container image by 40 MB, by excluding Javascript source map files from the container image. The source map files are only needed for debugging the frontend with the web browser's developer tools console; ordinary users (who would be running ImSwitch via the Docker container image) would not need to use it, so the source map files are useless for them.

Merging this PR would reduce the amount of data a user needs to download in a software upgrade which only changes some Python or Javascript source files in ImSwitch, from ~180 MB to ~140 MB. That's a reduction of ~22% in the download size.