### PR TITLE
Add pixel calibration UI, APIs and verification tab

### DIFF
--- a/frontend/src/axon/LiveViewControlWrapper.js
+++ b/frontend/src/axon/LiveViewControlWrapper.js
@@ -50,6 +50,10 @@ const pulse = keyframes`
  * @param {function} onImageLoad - Callback when image dimensions change: (width, height)
  * @param {React.ReactNode} overlayContent - Optional overlay content to render on top of the viewer
  * @param {boolean} enableStageMovement - Enable default double-click stage movement behavior (default: true)
+ * @param {boolean} enableZoomPan - Wrap the viewer in the zoom/pan shell (default: true).
+ *   Set to false for precise single-click workflows (e.g. pixel calibration marking):
+ *   the react-zoom-pan-pinch panning layer otherwise intercepts pointer events and
+ *   swallows the click, so the viewer is rendered directly and clicks reach the canvas.
  */
 const LiveViewControlWrapper = ({
   useFastMode = true,
@@ -57,6 +61,7 @@ const LiveViewControlWrapper = ({
   onImageLoad,
   overlayContent,
   enableStageMovement = true,
+  enableZoomPan = true,
 }) => {
   const dispatch = useDispatch();
   const objectiveState = useSelector(objectiveSlice.getObjectiveState);
@@ -446,7 +451,7 @@ const LiveViewControlWrapper = ({
           }}
         />
 
-        {liveViewState.isStreamRunning ? (
+        {liveViewState.isStreamRunning && enableZoomPan ? (
           <TransformWrapper
             key={`zoom-shell-${liveStreamState.imageFormat}-${liveViewState.isStreamRunning}`}
             initialScale={1}

--- a/frontend/src/backendapi/apiPixelCalibrationControllerGetCalibrationProgress.js
+++ b/frontend/src/backendapi/apiPixelCalibrationControllerGetCalibrationProgress.js
@@ -1,0 +1,12 @@
+// Poll the live progress of the running automatic calibration.
+import createAxiosInstance from './createAxiosInstance';
+
+const apiPixelCalibrationControllerGetCalibrationProgress = async () => {
+  const axiosInstance = createAxiosInstance();
+  const response = await axiosInstance.get(
+    '/PixelCalibrationController/getCalibrationProgress'
+  );
+  return response.data;
+};
+
+export default apiPixelCalibrationControllerGetCalibrationProgress;

--- a/frontend/src/backendapi/apiPixelCalibrationControllerResetDetectorFlip.js
+++ b/frontend/src/backendapi/apiPixelCalibrationControllerResetDetectorFlip.js
@@ -1,0 +1,19 @@
+// Reset a detector's image flip to off (used before manual calibration so the
+// user marks feature points on the raw, unflipped sensor).
+import createAxiosInstance from './createAxiosInstance';
+
+const apiPixelCalibrationControllerResetDetectorFlip = async (detectorName) => {
+  const axiosInstance = createAxiosInstance();
+  const params = {};
+  if (detectorName !== null && detectorName !== undefined && detectorName !== '') {
+    params.detectorName = String(detectorName);
+  }
+  const response = await axiosInstance.post(
+    '/PixelCalibrationController/resetDetectorFlip',
+    null,
+    { params }
+  );
+  return response.data;
+};
+
+export default apiPixelCalibrationControllerResetDetectorFlip;

--- a/frontend/src/backendapi/apiPixelCalibrationControllerStopCalibration.js
+++ b/frontend/src/backendapi/apiPixelCalibrationControllerStopCalibration.js
@@ -1,0 +1,12 @@
+// Request the running automatic calibration to abort at the next step.
+import createAxiosInstance from './createAxiosInstance';
+
+const apiPixelCalibrationControllerStopCalibration = async () => {
+  const axiosInstance = createAxiosInstance();
+  const response = await axiosInstance.post(
+    '/PixelCalibrationController/stopPixelCalibration'
+  );
+  return response.data;
+};
+
+export default apiPixelCalibrationControllerStopCalibration;

--- a/frontend/src/components/FRAMESettings/ManualPixelCalibrationTab.js
+++ b/frontend/src/components/FRAMESettings/ManualPixelCalibrationTab.js
@@ -19,6 +19,9 @@ import {
   Chip,
   Divider,
   CircularProgress,
+  Switch,
+  FormControlLabel,
+  Tooltip,
 } from '@mui/material';
 import {
   MyLocation as CrosshairIcon,
@@ -36,6 +39,7 @@ import apiPixelCalibrationControllerManualFourPointCalibration from '../../backe
 import apiPixelCalibrationControllerGetAvailableDetectors from '../../backendapi/apiPixelCalibrationControllerGetAvailableDetectors';
 import apiPixelCalibrationControllerGetCalibrationData from '../../backendapi/apiPixelCalibrationControllerGetCalibrationData';
 import apiPixelCalibrationControllerSetCalibrationData from '../../backendapi/apiPixelCalibrationControllerSetCalibrationData';
+import apiPixelCalibrationControllerResetDetectorFlip from '../../backendapi/apiPixelCalibrationControllerResetDetectorFlip';
 import apiObjectiveControllerGetStatus from '../../backendapi/apiObjectiveControllerGetStatus';
 import apiLiveViewControllerGetStreamParameters from '../../backendapi/apiLiveViewControllerGetStreamParameters';
 
@@ -90,7 +94,10 @@ const ManualPixelCalibrationTab = () => {
   const [backlashDistanceUm, setBacklashDistanceUm] = useState(50);
   const [detectorName, setDetectorName] = useState('');
   const [availableDetectors, setAvailableDetectors] = useState([]);
-  const [objectiveId, setObjectiveId] = useState('');
+  const [objectiveId, setObjectiveId] = useState('current');
+  // When on, the stage moves automatically after marking the first point of an
+  // axis so the user can immediately mark the second point (no separate "Move").
+  const [autoMove, setAutoMove] = useState(true);
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState('');
   const [error, setError] = useState('');
@@ -198,11 +205,22 @@ const ManualPixelCalibrationTab = () => {
     setError('');
   };
 
+  // Flip must be off while marking, otherwise the four-point math compensates a
+  // second time on an already-flipped live view and inverts the axes (#10).
+  // Reset it as the user enters the marking phase so points are captured on the
+  // raw sensor; the correct flip is re-applied when the calibration is accepted.
+  const resetFlipForCalibration = useCallback(async () => {
+    try {
+      await apiPixelCalibrationControllerResetDetectorFlip(detectorName || undefined);
+    } catch (_e) { /* non-fatal: leave flip as-is */ }
+  }, [detectorName]);
+
   // ---- step 0: backlash compensation ----
   const handleBacklashMove = async () => {
     try {
       setLoading(true);
       setError('');
+      await resetFlipForCalibration();
       setStatus(`Backlash pre-move: ${backlashDistanceUm} µm along X…`);
       await apiPositionerControllerMovePositioner({
         axis: 'X',
@@ -217,6 +235,13 @@ const ManualPixelCalibrationTab = () => {
     } finally {
       setLoading(false);
     }
+  };
+
+  // Skip backlash but still reset flip before the first mark.
+  const handleSkipBacklashX = async () => {
+    await resetFlipForCalibration();
+    setStatus('Flip reset. Click a recognisable feature in the image.');
+    setActiveStep(1);
   };
 
   const handleBacklashMoveY = async () => {
@@ -307,6 +332,22 @@ const ManualPixelCalibrationTab = () => {
       setLoading(false);
     }
   };
+
+  // ---- auto-advance: move the stage automatically after the first point ----
+  // When enabled, marking P1 (step 1 -> 2) or P3 (step 5 -> 6) kicks off the
+  // matching stage move so the user can immediately mark the second point.
+  // Deps are intentionally limited to [activeStep, autoMove] so the move fires
+  // exactly once per transition; a failed move leaves the manual button as a
+  // fallback. eslint-disable-next-line keeps the move handlers out of deps.
+  useEffect(() => {
+    if (!autoMove || loading) return;
+    if (activeStep === 2 && pointA1) {
+      handleMoveStageX();
+    } else if (activeStep === 6 && pointB1) {
+      handleMoveStageY();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeStep, autoMove]);
 
   // ---- step 8: compute calibration (does NOT save yet) ----
   const handleCalculate = async () => {
@@ -476,8 +517,9 @@ const ManualPixelCalibrationTab = () => {
   return (
     <Box>
       <Grid container spacing={3}>
-        {/* ---- Left: Live View ---- */}
+        {/* ---- Left: Live View (sticky so it stays visible while the workflow scrolls) ---- */}
         <Grid item xs={12} md={7}>
+          <Box sx={{ position: { xs: 'static', md: 'sticky' }, top: { md: 16 } }}>
           <Paper sx={{ p: 2 }}>
             <Typography variant="h6" gutterBottom>
               Detector Camera
@@ -497,6 +539,7 @@ const ManualPixelCalibrationTab = () => {
                 onImageLoad={(w, h) => setImageDims({ width: w, height: h })}
                 overlayContent={renderOverlay()}
                 enableStageMovement={false}
+                enableZoomPan={false}
               />
             </Box>
 
@@ -517,6 +560,7 @@ const ManualPixelCalibrationTab = () => {
               {subsamplingFactor > 1 && <Chip label={`Subsampling ×${subsamplingFactor}`} variant="outlined" size="small" />}
             </Box>
           </Paper>
+          </Box>
         </Grid>
 
         {/* ---- Right: Controls ---- */}
@@ -547,7 +591,7 @@ const ManualPixelCalibrationTab = () => {
             <FormControl fullWidth sx={{ mb: 1 }}>
               <InputLabel>Objective</InputLabel>
               <Select value={objectiveId} label="Objective" onChange={(e) => setObjectiveId(e.target.value)}>
-                <MenuItem value="">Current</MenuItem>
+                <MenuItem value="current">Current</MenuItem>
                 <MenuItem value="0">Objective 0</MenuItem>
                 <MenuItem value="1">Objective 1</MenuItem>
               </Select>
@@ -593,11 +637,15 @@ const ManualPixelCalibrationTab = () => {
                 const px = parseFloat(editPixelSizeUm);
                 if (!isFinite(px) || px <= 0) { setError('Pixel size must be positive'); return; }
                 setEditLoading(true); setError('');
+                // Preserve the calibration-owned flip: a pixel-size tweak must not
+                // silently un-flip the image (that is the #11 reset annoyance).
+                const sgnX = Number(existingCalib?.metrics?.scale_x_um_per_pixel ?? 1) < 0 ? -1 : 1;
+                const sgnY = Number(existingCalib?.metrics?.scale_y_um_per_pixel ?? 1) < 0 ? -1 : 1;
                 try {
                   const resp = await apiPixelCalibrationControllerSetCalibrationData({
                     detectorName, objectiveId: objectiveId || undefined,
-                    affineMatrix: [[px, 0.0, 0.0], [0.0, px, 0.0]],
-                    metrics: { scale_x_um_per_pixel: px, scale_y_um_per_pixel: px, rotation_deg: 0.0, method: 'manual_edit', quality: 'manual' },
+                    affineMatrix: [[px * sgnX, 0.0, 0.0], [0.0, px * sgnY, 0.0]],
+                    metrics: { scale_x_um_per_pixel: px * sgnX, scale_y_um_per_pixel: px * sgnY, rotation_deg: 0.0, method: 'manual_edit', quality: 'manual' },
                   });
                   if (resp?.success) {
                     setStatus(resp.message || 'Calibration saved');
@@ -610,7 +658,16 @@ const ManualPixelCalibrationTab = () => {
 
           {/* Stepper workflow */}
           <Paper sx={{ p: 2, mb: 2 }}>
-            <Typography variant="h6" gutterBottom>Four-Point Calibration Workflow</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+              <Typography variant="h6" gutterBottom>Four-Point Calibration Workflow</Typography>
+              <Tooltip title="After you mark the first point of an axis, the stage moves automatically by the configured distance so you can immediately mark the same feature again. Turn off to move the stage manually.">
+                <FormControlLabel
+                  control={<Switch size="small" checked={autoMove} onChange={(e) => setAutoMove(e.target.checked)} />}
+                  label="Auto-move stage"
+                  sx={{ mr: 0 }}
+                />
+              </Tooltip>
+            </Box>
 
             <Stepper activeStep={activeStep} orientation="vertical">
               {/* Step 0 – backlash */}
@@ -630,7 +687,7 @@ const ManualPixelCalibrationTab = () => {
                       onClick={handleBacklashMove} disabled={loading}>
                       {loading ? 'Moving…' : 'Move'}
                     </Button>
-                    <Button variant="outlined" size="small" onClick={() => setActiveStep(1)}>Skip</Button>
+                    <Button variant="outlined" size="small" onClick={handleSkipBacklashX}>Skip</Button>
                   </Box>
                 </StepContent>
               </Step>

--- a/frontend/src/components/FRAMESettings/PixelCalibrationTab.js
+++ b/frontend/src/components/FRAMESettings/PixelCalibrationTab.js
@@ -12,9 +12,8 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
-  FormControlLabel,
-  Checkbox,
   Divider,
+  LinearProgress,
 } from '@mui/material';
 
 import LiveViewControlWrapper from '../../axon/LiveViewControlWrapper';
@@ -23,6 +22,8 @@ import apiPixelCalibrationControllerGetPendingCalibration from '../../backendapi
 import apiPixelCalibrationControllerApplyPendingCalibration from '../../backendapi/apiPixelCalibrationControllerApplyPendingCalibration';
 import apiPixelCalibrationControllerDiscardPendingCalibration from '../../backendapi/apiPixelCalibrationControllerDiscardPendingCalibration';
 import apiPixelCalibrationControllerGetAvailableDetectors from '../../backendapi/apiPixelCalibrationControllerGetAvailableDetectors';
+import apiPixelCalibrationControllerGetCalibrationProgress from '../../backendapi/apiPixelCalibrationControllerGetCalibrationProgress';
+import apiPixelCalibrationControllerStopCalibration from '../../backendapi/apiPixelCalibrationControllerStopCalibration';
 import apiObjectiveControllerGetStatus from '../../backendapi/apiObjectiveControllerGetStatus';
 
 /**
@@ -39,8 +40,8 @@ const PixelCalibrationTab = () => {
   // --- selection / parameters ---
   const [detectorName, setDetectorName] = useState('');
   const [availableDetectors, setAvailableDetectors] = useState([]);
-  // Objective: '' = current, '0', '1' (string so it survives the round-trip).
-  const [objectiveId, setObjectiveId] = useState('');
+  // Objective: 'current' = active slot, '0', '1' (string so it survives the round-trip).
+  const [objectiveId, setObjectiveId] = useState('current');
   const [stepSizeUm, setStepSizeUm] = useState(100.0);
   const [pattern, setPattern] = useState('cross');
   const [nSteps, setNSteps] = useState(4);
@@ -85,13 +86,13 @@ const PixelCalibrationTab = () => {
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState('');
   const [error, setError] = useState('');
+  const [progress, setProgress] = useState(null); // {step,total,message} while running
+  const [stopping, setStopping] = useState(false);
 
   // --- pending calibration review state ---
   const [pending, setPending] = useState(null); // raw pending payload from backend
   const [editPixelSizeX, setEditPixelSizeX] = useState('');
   const [editPixelSizeY, setEditPixelSizeY] = useState('');
-  const [editFlipX, setEditFlipX] = useState(false);
-  const [editFlipY, setEditFlipY] = useState(false);
   const [editAffineMatrix, setEditAffineMatrix] = useState('');
 
   const pollRef = useRef(null);
@@ -104,8 +105,6 @@ const PixelCalibrationTab = () => {
     const sy = Number(data?.metrics?.scale_y_um_per_pixel ?? 0);
     setEditPixelSizeX(Math.abs(sx).toString());
     setEditPixelSizeY(Math.abs(sy).toString());
-    setEditFlipX(sx < 0);
-    setEditFlipY(sy < 0);
     setEditAffineMatrix(JSON.stringify(data?.affine_matrix ?? [], null, 2));
   };
 
@@ -116,29 +115,60 @@ const PixelCalibrationTab = () => {
     }
   };
 
-  // Poll while loading and no pending yet
+  // Poll progress + pending while a run is in flight.
   useEffect(() => {
     if (!loading || !detectorName) return undefined;
     pollRef.current = setInterval(async () => {
+      // Live progress for the bar / status line.
+      try {
+        const prog = await apiPixelCalibrationControllerGetCalibrationProgress();
+        if (prog?.success) setProgress(prog);
+      } catch (_e) { /* ignore */ }
+
       try {
         const resp = await apiPixelCalibrationControllerGetPendingCalibration(
           detectorName,
           objectiveId,
         );
         const data = resp?.pending ?? resp;
+        if (data && data.error) {
+          // The background thread failed – surface it instead of polling forever.
+          setError(`Calibration failed: ${data.error}`);
+          setStatus('');
+          setLoading(false);
+          setStopping(false);
+          setProgress(null);
+          stopPolling();
+          return;
+        }
         if (data && (data.affine_matrix || data.metrics)) {
           setPending(data);
           populateReviewFromPending(data);
           setLoading(false);
+          setStopping(false);
+          setProgress(null);
           setStatus('Calibration complete – please review and apply.');
           stopPolling();
         }
       } catch (err) {
         // keep polling unless backend explicitly errors
       }
-    }, 2000);
+    }, 1000);
     return stopPolling;
   }, [loading, detectorName, objectiveId]);
+
+  // If the user stopped the run (no pending result will appear), detect the
+  // "not running anymore" transition via progress and exit the loading state.
+  useEffect(() => {
+    if (!loading || !stopping) return;
+    if (progress && progress.running === false) {
+      setLoading(false);
+      setStopping(false);
+      setStatus(progress.message || 'Calibration stopped.');
+      setProgress(null);
+      stopPolling();
+    }
+  }, [loading, stopping, progress]);
 
   // --- actions ---------------------------------------------------------------
 
@@ -151,9 +181,11 @@ const PixelCalibrationTab = () => {
       setError('');
       setStatus('Calibration started in background – polling for result…');
       setPending(null);
+      setProgress(null);
+      setStopping(false);
       setLoading(true);
 
-      await apiPixelCalibrationControllerCalibrateStageAffine({
+      const resp = await apiPixelCalibrationControllerCalibrateStageAffine({
         detectorName,
         objectiveId,
         stepSizeUm,
@@ -161,10 +193,26 @@ const PixelCalibrationTab = () => {
         nSteps,
         backlashUm,
       });
+      // The backend rejects synchronously on bad camera intensity / busy state.
+      if (resp && resp.success === false) {
+        setLoading(false);
+        setStatus('');
+        setError(resp.error || 'Calibration could not be started.');
+      }
     } catch (err) {
       setLoading(false);
       setError(`Failed to start calibration: ${err.message}`);
       setStatus('');
+    }
+  };
+
+  const handleStop = async () => {
+    try {
+      setStopping(true);
+      setStatus('Stopping calibration…');
+      await apiPixelCalibrationControllerStopCalibration();
+    } catch (err) {
+      setError(`Failed to stop: ${err.message}`);
     }
   };
 
@@ -180,9 +228,12 @@ const PixelCalibrationTab = () => {
         return;
       }
 
-      // Re-encode flips into signed scale values (the backend convention)
-      const sx = Math.abs(parseFloat(editPixelSizeX)) * (editFlipX ? -1 : 1);
-      const sy = Math.abs(parseFloat(editPixelSizeY)) * (editFlipY ? -1 : 1);
+      // Flip is purely calibration-derived: keep the sign the calibration
+      // measured and only let the user adjust the pixel-size magnitude.
+      const measuredSx = Number(pending?.metrics?.scale_x_um_per_pixel ?? 0);
+      const measuredSy = Number(pending?.metrics?.scale_y_um_per_pixel ?? 0);
+      const sx = Math.abs(parseFloat(editPixelSizeX)) * (measuredSx < 0 ? -1 : 1);
+      const sy = Math.abs(parseFloat(editPixelSizeY)) * (measuredSy < 0 ? -1 : 1);
 
       const metrics = {
         ...(pending?.metrics ?? {}),
@@ -220,8 +271,9 @@ const PixelCalibrationTab = () => {
   return (
     <Box>
       <Grid container spacing={3}>
-        {/* Left: live detector view */}
+        {/* Left: live detector view (sticky so it stays visible while the right column scrolls) */}
         <Grid item xs={12} md={7}>
+          <Box sx={{ position: { xs: 'static', md: 'sticky' }, top: { md: 16 } }}>
           <Paper sx={{ p: 2 }}>
             <Typography variant="h6" gutterBottom>
               Detector Live View
@@ -243,6 +295,7 @@ const PixelCalibrationTab = () => {
               <LiveViewControlWrapper useFastMode={true} />
             </Box>
           </Paper>
+          </Box>
         </Grid>
 
         {/* Right: parameters + review */}
@@ -292,7 +345,7 @@ const PixelCalibrationTab = () => {
                 label="Objective"
                 onChange={(e) => setObjectiveId(e.target.value)}
               >
-                <MenuItem value="">Current</MenuItem>
+                <MenuItem value="current">Current</MenuItem>
                 <MenuItem value="0">Objective 0</MenuItem>
                 <MenuItem value="1">Objective 1</MenuItem>
               </Select>
@@ -361,23 +414,55 @@ const PixelCalibrationTab = () => {
               inputProps={{ step: 10, min: 0 }}
             />
 
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleCalibrate}
-              disabled={loading || !detectorName}
-              fullWidth
-              size="large"
-            >
-              {loading ? (
-                <>
-                  <CircularProgress size={22} sx={{ mr: 1 }} />
-                  Running…
-                </>
-              ) : (
-                'Start calibration'
-              )}
-            </Button>
+            {!loading ? (
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleCalibrate}
+                disabled={!detectorName}
+                fullWidth
+                size="large"
+              >
+                Start calibration
+              </Button>
+            ) : (
+              <Button
+                variant="contained"
+                color="error"
+                onClick={handleStop}
+                disabled={stopping}
+                fullWidth
+                size="large"
+              >
+                {stopping ? (
+                  <>
+                    <CircularProgress size={22} sx={{ mr: 1, color: 'inherit' }} />
+                    Stopping…
+                  </>
+                ) : (
+                  'Stop calibration'
+                )}
+              </Button>
+            )}
+
+            {/* Progress bar while a run is in flight */}
+            {loading && (
+              <Box sx={{ mt: 2 }}>
+                <LinearProgress
+                  variant={progress && progress.total > 0 ? 'determinate' : 'indeterminate'}
+                  value={
+                    progress && progress.total > 0
+                      ? Math.min(100, Math.round((progress.step / progress.total) * 100))
+                      : undefined
+                  }
+                />
+                <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+                  {progress && progress.total > 0
+                    ? `Step ${progress.step}/${progress.total}${progress.message ? ` – ${progress.message}` : ''}`
+                    : (progress?.message || 'Working…')}
+                </Typography>
+              </Box>
+            )}
           </Paper>
 
           {/* Pending calibration review */}
@@ -390,6 +475,22 @@ const PixelCalibrationTab = () => {
                 Verify the values below. Nothing is applied to the detector
                 until you press <b>Apply</b>.
               </Alert>
+
+              {pending?.metrics?.validation_ok === false && (
+                <Alert severity="error" sx={{ mb: 2 }}>
+                  Quality check failed: {pending.metrics.validation_message || 'low-quality calibration'}.
+                  The pixel size may be unreliable — consider re-running with more
+                  contrast/exposure or a larger step size.
+                </Alert>
+              )}
+              {pending?.metrics?.validation_ok === true && (
+                <Alert severity="success" sx={{ mb: 2 }}>
+                  Quality check passed
+                  {pending?.metrics?.mean_correlation != null
+                    ? ` (mean correlation ${Number(pending.metrics.mean_correlation).toFixed(2)})`
+                    : ''}.
+                </Alert>
+              )}
 
               <Grid container spacing={2}>
                 <Grid item xs={6}>
@@ -410,27 +511,15 @@ const PixelCalibrationTab = () => {
                     fullWidth
                   />
                 </Grid>
-                <Grid item xs={6}>
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        checked={editFlipX}
-                        onChange={(e) => setEditFlipX(e.target.checked)}
-                      />
-                    }
-                    label="Flip X"
-                  />
-                </Grid>
-                <Grid item xs={6}>
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        checked={editFlipY}
-                        onChange={(e) => setEditFlipY(e.target.checked)}
-                      />
-                    }
-                    label="Flip Y"
-                  />
+                <Grid item xs={12}>
+                  <Alert severity="info" icon={false} sx={{ py: 0.5 }}>
+                    <Typography variant="body2">
+                      <strong>Image flip (measured by calibration):</strong>{' '}
+                      X&nbsp;{Number(pending?.metrics?.scale_x_um_per_pixel ?? 0) < 0 ? 'flipped' : 'normal'},{' '}
+                      Y&nbsp;{Number(pending?.metrics?.scale_y_um_per_pixel ?? 0) < 0 ? 'flipped' : 'normal'}.
+                      Flip is calibration-owned and applied automatically on Apply.
+                    </Typography>
+                  </Alert>
                 </Grid>
               </Grid>
 

--- a/frontend/src/components/FRAMESettings/StageOffsetCalibrationTab.js
+++ b/frontend/src/components/FRAMESettings/StageOffsetCalibrationTab.js
@@ -947,6 +947,21 @@ const StageOffsetCalibrationTab = () => {
         position to the known physical coordinate.
       </Typography>
 
+      <Alert severity="info" sx={{ mb: 2 }}>
+        <Typography variant="body2">
+          <strong>What this does:</strong> it anchors the stage&apos;s device
+          coordinates to a known physical reference so absolute moves and known
+          well-plate / chart layouts line up with the real sample.
+        </Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          <strong>Step 1 — Insert slide &amp; start scan:</strong> put the reference
+          slide in, then raster-scan a small area; the heatmap shows where the
+          reference feature (e.g. a bright hole) is.<br />
+          <strong>Step 2 — Review &amp; accept:</strong> click the feature on the
+          heatmap to pick it (or accept the brightest), then store the offset.
+        </Typography>
+      </Alert>
+
       {!homingAck && (
         <Alert
           severity="warning"

--- a/frontend/src/components/FRAMESettings/VerifyCalibrationTab.js
+++ b/frontend/src/components/FRAMESettings/VerifyCalibrationTab.js
@@ -1,0 +1,364 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  Box,
+  Button,
+  Typography,
+  Grid,
+  Paper,
+  Alert,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  TextField,
+  Chip,
+  Divider,
+  IconButton,
+  Tooltip,
+} from '@mui/material';
+import {
+  ArrowUpward,
+  ArrowDownward,
+  ArrowBack,
+  ArrowForward,
+  Replay as ResetIcon,
+  Clear as ClearIcon,
+} from '@mui/icons-material';
+
+import LiveViewControlWrapper from '../../axon/LiveViewControlWrapper';
+import * as liveStreamSlice from '../../state/slices/LiveStreamSlice';
+import apiPositionerControllerMovePositioner from '../../backendapi/apiPositionerControllerMovePositioner';
+import apiPixelCalibrationControllerGetAvailableDetectors from '../../backendapi/apiPixelCalibrationControllerGetAvailableDetectors';
+import apiPixelCalibrationControllerGetCalibrationData from '../../backendapi/apiPixelCalibrationControllerGetCalibrationData';
+import apiLiveViewControllerGetStreamParameters from '../../backendapi/apiLiveViewControllerGetStreamParameters';
+
+/**
+ * VerifyCalibrationTab – visually sanity-check the *current* pixel-size calibration.
+ *
+ * Mark a recognisable feature in the live image, then nudge the stage by a known
+ * distance (default 50 µm) up / down / left / right. The overlay draws:
+ *   • the fixed crosshair where you marked the feature,
+ *   • an "expected distance" ring (radius = move distance / pixel size), and
+ *   • a predicted crosshair (direction from the stored affine matrix).
+ * If the calibration is correct the feature lands on the predicted marker / ring.
+ */
+const VerifyCalibrationTab = () => {
+  const liveStreamState = useSelector(liveStreamSlice.getLiveStreamState);
+
+  const [detectorName, setDetectorName] = useState('');
+  const [availableDetectors, setAvailableDetectors] = useState([]);
+  const [objectiveId, setObjectiveId] = useState('current');
+  const [moveDistanceUm, setMoveDistanceUm] = useState(50);
+
+  const [calib, setCalib] = useState(null); // { pixelSizeUm, affine2x2 }
+  const [markedPoint, setMarkedPoint] = useState(null); // {x,y} in preview px
+  const [imageDims, setImageDims] = useState(null);
+  const [netMove, setNetMove] = useState({ dx: 0, dy: 0 }); // µm since the mark
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+
+  const [backendSubsampling, setBackendSubsampling] = useState(null);
+  const subsamplingFromRedux = useMemo(() => {
+    const s = liveStreamState.streamSettings;
+    return s?.jpeg?.subsampling?.factor || s?.jpeg?.subsampling_factor ||
+           s?.binary?.subsampling?.factor || s?.webrtc?.subsampling_factor || null;
+  }, [liveStreamState.streamSettings]);
+  const subsamplingFactor = backendSubsampling ?? subsamplingFromRedux ?? 1;
+
+  // --- load detectors once ---
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await apiPixelCalibrationControllerGetAvailableDetectors();
+        if (cancelled) return;
+        const names = resp?.detectorNames || [];
+        setAvailableDetectors(names);
+        if (names.length > 0) setDetectorName((prev) => prev || names[0]);
+      } catch (_e) { /* ignore */ }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // --- pull the real subsampling factor from the backend ---
+  useEffect(() => {
+    (async () => {
+      try {
+        const resp = await apiLiveViewControllerGetStreamParameters();
+        const active = resp?.current_protocol;
+        const protos = resp?.protocols || {};
+        let factor = null;
+        if (active && protos[active]?.subsampling_factor != null) {
+          factor = Number(protos[active].subsampling_factor);
+        } else {
+          for (const p of Object.keys(protos)) {
+            if (protos[p]?.subsampling_factor != null) { factor = Number(protos[p].subsampling_factor); break; }
+          }
+        }
+        if (factor && factor > 0) setBackendSubsampling(factor);
+      } catch (_e) { /* keep redux fallback */ }
+    })();
+  }, []);
+
+  // --- load the calibration to verify whenever detector / objective changes ---
+  useEffect(() => {
+    let cancelled = false;
+    if (!detectorName) { setCalib(null); return undefined; }
+    (async () => {
+      try {
+        const resp = await apiPixelCalibrationControllerGetCalibrationData(detectorName, objectiveId);
+        if (cancelled) return;
+        if (resp?.success) {
+          const m = resp.metrics || {};
+          const sx = Number(m.scale_x_um_per_pixel ?? 0);
+          const sy = Number(m.scale_y_um_per_pixel ?? 0);
+          const pixelSizeUm = (Math.abs(sx) + Math.abs(sy)) / 2 || null;
+          const A = resp.affineMatrix; // 2x3 [[a,b,tx],[c,d,ty]]
+          const affine2x2 = (Array.isArray(A) && A.length >= 2)
+            ? [[Number(A[0][0]), Number(A[0][1])], [Number(A[1][0]), Number(A[1][1])]]
+            : null;
+          setCalib({ pixelSizeUm, affine2x2, scaleX: sx, scaleY: sy });
+        } else {
+          setCalib(null);
+        }
+      } catch (_e) { setCalib(null); }
+    })();
+    return () => { cancelled = true; };
+  }, [detectorName, objectiveId]);
+
+  const handleImageClick = useCallback((pixelX, pixelY, w, h) => {
+    if (!imageDims) setImageDims({ width: w, height: h });
+    setMarkedPoint({ x: pixelX, y: pixelY });
+    setNetMove({ dx: 0, dy: 0 });
+    setStatus(`Marked (${Math.round(pixelX)}, ${Math.round(pixelY)}). Nudge the stage to check the calibration.`);
+  }, [imageDims]);
+
+  const nudge = async (dx, dy) => {
+    try {
+      setLoading(true); setError('');
+      if (dx !== 0) {
+        await apiPositionerControllerMovePositioner({ axis: 'X', dist: dx, isAbsolute: false, isBlocking: true });
+      }
+      if (dy !== 0) {
+        await apiPositionerControllerMovePositioner({ axis: 'Y', dist: dy, isAbsolute: false, isBlocking: true });
+      }
+      setNetMove((p) => ({ dx: p.dx + dx, dy: p.dy + dy }));
+      setStatus('Stage moved. Compare the feature to the predicted marker / ring.');
+    } catch (err) {
+      setError(`Stage move failed: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const returnToStart = async () => {
+    if (netMove.dx === 0 && netMove.dy === 0) return;
+    await nudge(-netMove.dx, -netMove.dy);
+    setNetMove({ dx: 0, dy: 0 });
+    setStatus('Returned to the marked position.');
+  };
+
+  const clearMark = () => {
+    setMarkedPoint(null);
+    setNetMove({ dx: 0, dy: 0 });
+    setStatus('');
+  };
+
+  // --- predicted pixel shift (preview px) for the accumulated stage move ---
+  // affine A maps sensor-pixel -> stage(µm): stage = A @ pixel. So a stage move
+  // of (dx,dy) µm shifts the image content by A⁻¹ @ (dx,dy) sensor px, which is
+  // (A⁻¹ @ move) / subsampling preview px.
+  const predicted = useMemo(() => {
+    if (!markedPoint || (netMove.dx === 0 && netMove.dy === 0)) return null;
+    if (!calib) return null;
+    const { affine2x2, pixelSizeUm } = calib;
+    let shiftSensor = null;
+    if (affine2x2) {
+      const [[a, b], [c, d]] = affine2x2;
+      const det = a * d - b * c;
+      if (Math.abs(det) > 1e-9) {
+        // A⁻¹ @ [dx,dy]
+        shiftSensor = {
+          x: (d * netMove.dx - b * netMove.dy) / det,
+          y: (-c * netMove.dx + a * netMove.dy) / det,
+        };
+      }
+    }
+    if (!shiftSensor && pixelSizeUm) {
+      // Fallback: magnitude only along the commanded axes (no rotation/flip info).
+      shiftSensor = { x: netMove.dx / pixelSizeUm, y: netMove.dy / pixelSizeUm };
+    }
+    if (!shiftSensor) return null;
+    const shiftPreview = { x: shiftSensor.x / subsamplingFactor, y: shiftSensor.y / subsamplingFactor };
+    const radius = Math.sqrt(shiftPreview.x ** 2 + shiftPreview.y ** 2);
+    return {
+      point: { x: markedPoint.x + shiftPreview.x, y: markedPoint.y + shiftPreview.y },
+      radius,
+      expectedUm: Math.sqrt(netMove.dx ** 2 + netMove.dy ** 2),
+    };
+  }, [markedPoint, netMove, calib, subsamplingFactor]);
+
+  const renderOverlay = () => {
+    if (!markedPoint) return null;
+    const c = '#00e5ff';
+    const p = '#ffea00';
+    return (
+      <svg
+        style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', pointerEvents: 'none', zIndex: 10 }}
+        viewBox={imageDims ? `0 0 ${imageDims.width} ${imageDims.height}` : '0 0 100 100'}
+        preserveAspectRatio="xMidYMid meet"
+      >
+        {/* marked feature crosshair */}
+        <line x1={markedPoint.x - 14} y1={markedPoint.y} x2={markedPoint.x + 14} y2={markedPoint.y} stroke={c} strokeWidth="2" />
+        <line x1={markedPoint.x} y1={markedPoint.y - 14} x2={markedPoint.x} y2={markedPoint.y + 14} stroke={c} strokeWidth="2" />
+        <circle cx={markedPoint.x} cy={markedPoint.y} r="6" fill="none" stroke={c} strokeWidth="2" />
+        {predicted && (
+          <>
+            {/* expected-distance ring */}
+            <circle cx={markedPoint.x} cy={markedPoint.y} r={predicted.radius} fill="none" stroke={p} strokeWidth="1.5" strokeDasharray="5,4" opacity="0.8" />
+            {/* predicted feature position */}
+            <line x1={predicted.point.x - 12} y1={predicted.point.y} x2={predicted.point.x + 12} y2={predicted.point.y} stroke={p} strokeWidth="2" />
+            <line x1={predicted.point.x} y1={predicted.point.y - 12} x2={predicted.point.x} y2={predicted.point.y + 12} stroke={p} strokeWidth="2" />
+            <line x1={markedPoint.x} y1={markedPoint.y} x2={predicted.point.x} y2={predicted.point.y} stroke={p} strokeWidth="1" strokeDasharray="3,3" opacity="0.6" />
+          </>
+        )}
+      </svg>
+    );
+  };
+
+  const dirBtn = (icon, title, dx, dy) => (
+    <Tooltip title={title}>
+      <span>
+        <IconButton color="primary" onClick={() => nudge(dx, dy)} disabled={loading || !markedPoint}>
+          {icon}
+        </IconButton>
+      </span>
+    </Tooltip>
+  );
+
+  return (
+    <Box>
+      <Grid container spacing={3}>
+        {/* Left: sticky live view */}
+        <Grid item xs={12} md={7}>
+          <Box sx={{ position: { xs: 'static', md: 'sticky' }, top: { md: 16 } }}>
+            <Paper sx={{ p: 2 }}>
+              <Typography variant="h6" gutterBottom>Detector Camera</Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                {markedPoint ? 'Nudge the stage and watch the feature vs. the yellow ring/marker.' : 'Click a recognisable feature to mark it.'}
+              </Typography>
+              <Box sx={{ border: '1px solid #ddd', borderRadius: 2, overflow: 'hidden', minHeight: 400, maxHeight: 520, backgroundColor: '#000', position: 'relative' }}>
+                <LiveViewControlWrapper
+                  useFastMode={true}
+                  onClick={handleImageClick}
+                  onImageLoad={(w, h) => setImageDims({ width: w, height: h })}
+                  overlayContent={renderOverlay()}
+                  enableStageMovement={false}
+                  enableZoomPan={false}
+                />
+              </Box>
+              <Box sx={{ mt: 1, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                {markedPoint && <Chip size="small" color="info" label={`Mark: (${Math.round(markedPoint.x)}, ${Math.round(markedPoint.y)})`} />}
+                {(netMove.dx !== 0 || netMove.dy !== 0) && <Chip size="small" color="warning" label={`Net move: X ${netMove.dx} µm, Y ${netMove.dy} µm`} />}
+                {predicted && <Chip size="small" variant="outlined" label={`Expected shift: ${predicted.radius.toFixed(1)} px`} />}
+                {subsamplingFactor > 1 && <Chip size="small" variant="outlined" label={`Subsampling ×${subsamplingFactor}`} />}
+              </Box>
+            </Paper>
+          </Box>
+        </Grid>
+
+        {/* Right: controls */}
+        <Grid item xs={12} md={5}>
+          {status && <Alert severity="info" sx={{ mb: 2 }} onClose={() => setStatus('')}>{status}</Alert>}
+          {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}
+
+          <Paper sx={{ p: 2, mb: 2 }}>
+            <Typography variant="h6" gutterBottom>Verify Calibration</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              A visual sanity check of the stored pixel size: mark a feature, move
+              the stage a known distance, and confirm the feature lands on the
+              predicted marker (yellow) and the expected-distance ring.
+            </Typography>
+
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <InputLabel>Detector</InputLabel>
+              <Select value={detectorName} label="Detector" onChange={(e) => setDetectorName(e.target.value)}>
+                {availableDetectors.length === 0 && <MenuItem value="" disabled><em>(no detectors)</em></MenuItem>}
+                {availableDetectors.map((n) => <MenuItem key={n} value={n}>{n}</MenuItem>)}
+              </Select>
+            </FormControl>
+
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <InputLabel>Objective</InputLabel>
+              <Select value={objectiveId} label="Objective" onChange={(e) => setObjectiveId(e.target.value)}>
+                <MenuItem value="current">Current</MenuItem>
+                <MenuItem value="0">Objective 0</MenuItem>
+                <MenuItem value="1">Objective 1</MenuItem>
+              </Select>
+            </FormControl>
+
+            {calib ? (
+              <Alert severity={calib.pixelSizeUm ? 'success' : 'warning'} sx={{ mb: 2 }}>
+                {calib.pixelSizeUm
+                  ? <>Pixel size to verify: <strong>{calib.pixelSizeUm.toFixed(4)} µm/px</strong>
+                      {(calib.scaleX < 0 || calib.scaleY < 0) && ' (flipped)'}</>
+                  : 'Calibration found but has no pixel size.'}
+              </Alert>
+            ) : (
+              <Alert severity="warning" sx={{ mb: 2 }}>
+                No calibration stored for this detector / objective — run a calibration first.
+              </Alert>
+            )}
+
+            <TextField
+              label="Move distance (µm)"
+              type="number"
+              value={moveDistanceUm}
+              onChange={(e) => setMoveDistanceUm(parseFloat(e.target.value) || 0)}
+              fullWidth size="small" sx={{ mb: 2 }}
+              inputProps={{ step: 10, min: 1 }}
+            />
+
+            {/* D-pad */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 1 }}>
+              {dirBtn(<ArrowUpward />, `Move +${moveDistanceUm} µm in Y`, 0, moveDistanceUm)}
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                {dirBtn(<ArrowBack />, `Move -${moveDistanceUm} µm in X`, -moveDistanceUm, 0)}
+                {dirBtn(<ArrowForward />, `Move +${moveDistanceUm} µm in X`, moveDistanceUm, 0)}
+              </Box>
+              {dirBtn(<ArrowDownward />, `Move -${moveDistanceUm} µm in Y`, 0, -moveDistanceUm)}
+            </Box>
+
+            <Divider sx={{ my: 1.5 }} />
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              <Button variant="outlined" startIcon={<ResetIcon />} onClick={returnToStart}
+                disabled={loading || (netMove.dx === 0 && netMove.dy === 0)} fullWidth>
+                Return to start
+              </Button>
+              <Button variant="outlined" color="secondary" startIcon={<ClearIcon />} onClick={clearMark}
+                disabled={!markedPoint} fullWidth>
+                Clear mark
+              </Button>
+            </Box>
+          </Paper>
+
+          <Paper sx={{ p: 2, backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(144,202,249,0.08)' : '#f0f7ff' }}>
+            <Typography variant="subtitle2" gutterBottom>How to read it</Typography>
+            <Typography variant="body2">
+              <span style={{ color: '#00b8d4' }}>●</span> Cyan crosshair = where you marked the feature.<br />
+              <span style={{ color: '#c8b900' }}>●</span> Yellow ring = expected distance for the move (= move ÷ pixel size).<br />
+              <span style={{ color: '#c8b900' }}>✛</span> Yellow crosshair = predicted feature position (direction from the affine).<br /><br />
+              If the calibration is correct, after the move the feature sits on the
+              yellow marker. If it falls short / overshoots the ring, the pixel size
+              is off; if it lands off-axis, the rotation/flip is off.
+            </Typography>
+          </Paper>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default VerifyCalibrationTab;

--- a/frontend/src/components/FRAMESettingsController.js
+++ b/frontend/src/components/FRAMESettingsController.js
@@ -5,6 +5,7 @@ import SetLasersTab from "./FRAMESettings/SetLasersTab";
 import TestHomingTab from "./FRAMESettings/TestHomingTab";
 import PixelCalibrationTab from "./FRAMESettings/PixelCalibrationTab";
 import ManualPixelCalibrationTab from "./FRAMESettings/ManualPixelCalibrationTab";
+import VerifyCalibrationTab from "./FRAMESettings/VerifyCalibrationTab";
 import ExtendedObjectiveController from "./ObjectiveController";
 import StageOffsetCalibrationTab from "./FRAMESettings/StageOffsetCalibrationTab";
 import OpticalFlowTab from "./FRAMESettings/OpticalFlowTab";
@@ -48,6 +49,7 @@ const FRAMESettings = () => {
       >
         <Tab value="autoPixel" label="Automatic Pixel Calibration" />
         <Tab value="manualPixel" label="Manual Pixel Calibration" />
+        <Tab value="verifyCalibration" label="Verify Calibration" />
         <Tab value="setLasers" label="Set Lasers" />
         <Tab value="testHoming" label="Test Homing" />
         {hasObjectiveController && (
@@ -60,6 +62,7 @@ const FRAMESettings = () => {
       <Box sx={{ mt: 2 }}>
         {selectedTab === "autoPixel" && <PixelCalibrationTab />}
         {selectedTab === "manualPixel" && <ManualPixelCalibrationTab />}
+        {selectedTab === "verifyCalibration" && <VerifyCalibrationTab />}
         {selectedTab === "setLasers" && <SetLasersTab />}
         {selectedTab === "testHoming" && <TestHomingTab />}
         {hasObjectiveController && selectedTab === "objective" && (

--- a/frontend/src/components/ObjectiveController.js
+++ b/frontend/src/components/ObjectiveController.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Paper, Grid, Button, Typography, TextField, Box } from "@mui/material";
+import { Paper, Grid, Button, Typography, TextField, Box, Tooltip, Alert } from "@mui/material";
 import LiveViewControlWrapper from "../axon/LiveViewControlWrapper";
 import ObjectiveCalibrationWizard from "./ObjectiveCalibrationWizard";
 import * as objectiveSlice from "../state/slices/ObjectiveSlice.js";
@@ -595,6 +595,42 @@ const ExtendedObjectiveController = () => {
           <Typography variant="subtitle1" gutterBottom>
             Objective Positions
           </Typography>
+          <Alert severity="info" sx={{ mb: 2 }}>
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              Two objectives sit in two slots on a motorised revolver. To switch
+              between them the revolver moves along its <strong>A / X axis</strong> to
+              each slot's stored position, and the <strong>Z (focus)</strong> moves to
+              each objective's par-focal height so the sample stays in focus.
+            </Typography>
+            <Box sx={{ display: 'flex', justifyContent: 'center', my: 1 }}>
+              <svg viewBox="0 0 360 130" width="100%" style={{ maxWidth: 360 }} role="img"
+                aria-label="Revolver with two objective slots along the X/A axis and a Z focus axis">
+                {/* X/A axis */}
+                <line x1="20" y1="40" x2="340" y2="40" stroke="currentColor" strokeWidth="1.5" opacity="0.6" />
+                <polygon points="340,40 332,36 332,44" fill="currentColor" opacity="0.6" />
+                <text x="300" y="30" fill="currentColor" fontSize="11" opacity="0.8">A / X axis</text>
+                {/* Slot 1 (Obj 1 @ X0) */}
+                <circle cx="110" cy="40" r="16" fill="none" stroke="#2e9b57" strokeWidth="2.5" />
+                <line x1="110" y1="40" x2="110" y2="70" stroke="#2e9b57" strokeWidth="2" strokeDasharray="3,3" />
+                <text x="110" y="92" fill="#2e9b57" fontSize="12" fontWeight="bold" textAnchor="middle">Obj 1</text>
+                <text x="110" y="106" fill="currentColor" fontSize="10" textAnchor="middle" opacity="0.8">X0 / Z0</text>
+                {/* Slot 2 (Obj 2 @ X1) */}
+                <circle cx="250" cy="40" r="16" fill="none" stroke="#3f7fd0" strokeWidth="2.5" />
+                <line x1="250" y1="40" x2="250" y2="70" stroke="#3f7fd0" strokeWidth="2" strokeDasharray="3,3" />
+                <text x="250" y="92" fill="#3f7fd0" fontSize="12" fontWeight="bold" textAnchor="middle">Obj 2</text>
+                <text x="250" y="106" fill="currentColor" fontSize="10" textAnchor="middle" opacity="0.8">X1 / Z1</text>
+                {/* Z axis */}
+                <line x1="320" y1="58" x2="320" y2="120" stroke="currentColor" strokeWidth="1.5" opacity="0.6" />
+                <polygon points="320,120 316,112 324,112" fill="currentColor" opacity="0.6" />
+                <text x="328" y="100" fill="currentColor" fontSize="11" opacity="0.8">Z focus</text>
+              </svg>
+            </Box>
+            <Typography variant="caption" color="text.secondary">
+              <strong>Position 1/2</strong> = the revolver X position for each objective.
+              <strong> Focus 1/2</strong> = the par-focal Z for each objective. Use
+              "Set Current as…" after manually driving the revolver/focus to the right spot.
+            </Typography>
+          </Alert>
           <Grid container spacing={2}>
             {/* X0 */}
             <Grid item xs={12} md={6} lg={3}>
@@ -620,38 +656,46 @@ const ExtendedObjectiveController = () => {
                   fullWidth
                   sx={{ my: 1 }}
                 />
-                <Button
-                  variant="contained"
-                  onClick={() => handleSetX0(objectiveState.manualX0)}
-                  fullWidth
-                  sx={{ mb: 1 }}
-                >
-                  Set Position 1
-                </Button>
-                <Button
-                  variant="outlined"
-                  onClick={() => handleSetCurrentAs("x0")}
-                  fullWidth
-                  sx={{ mb: 1 }}
-                >
-                  Set Current as Position 1
-                </Button>
-                <Button
-                  variant="outlined"
-                  color="secondary"
-                  onClick={() => handleSwitchObjective(0, true)}
-                  fullWidth
-                >
-                  Switch to Objective 1
-                </Button>
-                <Button
-                  variant="outlined"
-                  color="secondary"
-                  onClick={() => handleSwitchObjective(0, false)}
-                  fullWidth
-                >
-                  Switch to Objective 1 (incl. Z)
-                </Button>
+                <Tooltip title="Store the typed value as objective 1's revolver X (A-axis) position.">
+                  <Button
+                    variant="contained"
+                    onClick={() => handleSetX0(objectiveState.manualX0)}
+                    fullWidth
+                    sx={{ mb: 1 }}
+                  >
+                    Set Position 1
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Use the revolver's current X position as objective 1's position (drive there first, then click).">
+                  <Button
+                    variant="outlined"
+                    onClick={() => handleSetCurrentAs("x0")}
+                    fullWidth
+                    sx={{ mb: 1 }}
+                  >
+                    Set Current as Position 1
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Move the revolver to objective 1's X position only (keeps current focus).">
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    onClick={() => handleSwitchObjective(0, true)}
+                    fullWidth
+                  >
+                    Switch to Objective 1
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Move the revolver to objective 1 AND its par-focal Z (Focus 1) so the sample stays in focus.">
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    onClick={() => handleSwitchObjective(0, false)}
+                    fullWidth
+                  >
+                    Switch to Objective 1 (incl. Z)
+                  </Button>
+                </Tooltip>
               </Box>
             </Grid>
             {/* X1 */}
@@ -679,38 +723,46 @@ const ExtendedObjectiveController = () => {
                   fullWidth
                   sx={{ my: 1 }}
                 />
-                <Button
-                  variant="contained"
-                  onClick={() => handleSetX1(objectiveState.manualX1)}
-                  fullWidth
-                  sx={{ mb: 1 }}
-                >
-                  Set Position 2
-                </Button>
-                <Button
-                  variant="outlined"
-                  onClick={() => handleSetCurrentAs("x1")}
-                  fullWidth
-                  sx={{ mb: 1 }}
-                >
-                  Set Current as Position 2
-                </Button>
-                <Button
-                  variant="outlined"
-                  color="secondary"
-                  onClick={() => handleSwitchObjective(1, true)}
-                  fullWidth
-                >
-                  Switch to Objective 2
-                </Button>
-                <Button
-                  variant="outlined"
-                  color="secondary"
-                  onClick={() => handleSwitchObjective(1, false)}
-                  fullWidth
-                >
-                  Switch to Objective 2 (incl. Z)
-                </Button>
+                <Tooltip title="Store the typed value as objective 2's revolver X (A-axis) position.">
+                  <Button
+                    variant="contained"
+                    onClick={() => handleSetX1(objectiveState.manualX1)}
+                    fullWidth
+                    sx={{ mb: 1 }}
+                  >
+                    Set Position 2
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Use the revolver's current X position as objective 2's position (drive there first, then click).">
+                  <Button
+                    variant="outlined"
+                    onClick={() => handleSetCurrentAs("x1")}
+                    fullWidth
+                    sx={{ mb: 1 }}
+                  >
+                    Set Current as Position 2
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Move the revolver to objective 2's X position only (keeps current focus).">
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    onClick={() => handleSwitchObjective(1, true)}
+                    fullWidth
+                  >
+                    Switch to Objective 2
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Move the revolver to objective 2 AND its par-focal Z (Focus 2) so the sample stays in focus.">
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    onClick={() => handleSwitchObjective(1, false)}
+                    fullWidth
+                  >
+                    Switch to Objective 2 (incl. Z)
+                  </Button>
+                </Tooltip>
               </Box>
             </Grid>
             )}
@@ -738,21 +790,25 @@ const ExtendedObjectiveController = () => {
                   fullWidth
                   sx={{ my: 1 }}
                 />
-                <Button
-                  variant="contained"
-                  onClick={() => handleSetZ0(manualZ0)}
-                  fullWidth
-                  sx={{ mb: 1 }}
-                >
-                  Set Focus 1
-                </Button>
-                <Button
-                  variant="outlined"
-                  onClick={() => handleSetCurrentAs("z0")}
-                  fullWidth
-                >
-                  Set Current as Focus 1
-                </Button>
+                <Tooltip title="Store the typed Z height that makes objective 1 par-focal (in focus).">
+                  <Button
+                    variant="contained"
+                    onClick={() => handleSetZ0(manualZ0)}
+                    fullWidth
+                    sx={{ mb: 1 }}
+                  >
+                    Set Focus 1
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Focus on the sample with objective 1, then click to store the current Z as its par-focal focus.">
+                  <Button
+                    variant="outlined"
+                    onClick={() => handleSetCurrentAs("z0")}
+                    fullWidth
+                  >
+                    Set Current as Focus 1
+                  </Button>
+                </Tooltip>
               </Box>
             </Grid>
             {/* Z1 */}
@@ -780,21 +836,25 @@ const ExtendedObjectiveController = () => {
                   fullWidth
                   sx={{ my: 1 }}
                 />
-                <Button
-                  variant="contained"
-                  onClick={() => handleSetZ1(manualZ1)}
-                  fullWidth
-                  sx={{ mb: 1 }}
-                >
-                  Set Focus 2
-                </Button>
-                <Button
-                  variant="outlined"
-                  onClick={() => handleSetCurrentAs("z1")}
-                  fullWidth
-                >
-                  Set Current as Focus 2
-                </Button>
+                <Tooltip title="Store the typed Z height that makes objective 2 par-focal (in focus).">
+                  <Button
+                    variant="contained"
+                    onClick={() => handleSetZ1(manualZ1)}
+                    fullWidth
+                    sx={{ mb: 1 }}
+                  >
+                    Set Focus 2
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Focus on the sample with objective 2, then click to store the current Z as its par-focal focus.">
+                  <Button
+                    variant="outlined"
+                    onClick={() => handleSetCurrentAs("z1")}
+                    fullWidth
+                  >
+                    Set Current as Focus 2
+                  </Button>
+                </Tooltip>
               </Box>
             </Grid>
             )}

--- a/frontend/src/components/ShitScopeComponent.js
+++ b/frontend/src/components/ShitScopeComponent.js
@@ -10,6 +10,10 @@ import {
   Alert,
   CircularProgress,
   Slider,
+  Tabs,
+  Tab,
+  TextField,
+  Divider,
 } from "@mui/material";
 import {
   PlayArrow as PlayArrowIcon,
@@ -48,6 +52,30 @@ const SHITSCOPE_SCAN_WIDTH = 15000; // 15 mm
 const SHITSCOPE_SCAN_HEIGHT = 7000; // 7 mm
 
 /**
+ * Build an ordered list of (x,y) stage positions for a snake-pattern tile scan.
+ * The origin is the current stage position; tiles are placed at stepSizeX / stepSizeY intervals.
+ */
+function buildTileEditorSnakePositions(baseX, baseY, numTilesX, numTilesY, stepSizeX, stepSizeY) {
+  const positions = [];
+  for (let iY = 0; iY < numTilesY; iY++) {
+    const row = [];
+    for (let iX = 0; iX < numTilesX; iX++) {
+      row.push({
+        x: baseX + iX * stepSizeX,
+        y: baseY + iY * stepSizeY,
+        z: 0,
+        iX,
+        iY,
+      });
+    }
+    // Reverse every other row for snake pattern
+    if (iY % 2 === 1) row.reverse();
+    positions.push(...row);
+  }
+  return positions;
+}
+
+/**
  * ShitScope - Dedicated single-button scan application
  *
  * Simplified scan interface with:
@@ -63,6 +91,15 @@ const ShitScopeComponent = ({ onOpenFileManager }) => {
 
   // Homing state
   const [isHoming, setIsHoming] = useState(false);
+
+  // Tab: 0 = Overview, 1 = Tile Editor
+  const [activeTab, setActiveTab] = useState(0);
+
+  // Tile editor parameters
+  const [tilesX, setTilesX] = useState(3);
+  const [tilesY, setTilesY] = useState(3);
+  const [stepSizeX, setStepSizeX] = useState(0);
+  const [stepSizeY, setStepSizeY] = useState(0);
 
   // Workflow step tracking
   const [cachedStepId, setCachedStepId] = useState(0);
@@ -162,9 +199,133 @@ const ShitScopeComponent = ({ onOpenFileManager }) => {
   const isRunning = experimentStatusState.status === Status.RUNNING;
   const isIdle = experimentStatusState.status === Status.IDLE;
 
+  // FOV info (needed by handleStart and the tile editor UI)
+  const fovX = objectiveState.fovX || 0;
+  const fovY = objectiveState.fovY || 0;
+  const pixelSize = objectiveState.pixelsize || 0;
+
+  // Keep stepSizeX/Y in sync with FOV as the suggested default (only while
+  // the user has not manually overridden them, i.e. while they equal 0).
+  useEffect(() => {
+    if (fovX > 0 && stepSizeX === 0) setStepSizeX(fovX);
+  }, [fovX]); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (fovY > 0 && stepSizeY === 0) setStepSizeY(fovY);
+  }, [fovY]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const tilesX_computed = fovX > 0 ? Math.ceil(SHITSCOPE_SCAN_WIDTH / fovX) : "?";
+  const tilesY_computed = fovY > 0 ? Math.ceil(SHITSCOPE_SCAN_HEIGHT / fovY) : "?";
+  const totalTiles_computed =
+    typeof tilesX_computed === "number" && typeof tilesY_computed === "number"
+      ? tilesX_computed * tilesY_computed
+      : "?";
+
   // ── Start experiment ───────────────────────────────────────────────────
   const handleStart = useCallback(async () => {
     try {
+      // ── TILE EDITOR MODE ─────────────────────────────────────────────
+      if (activeTab === 1) {
+        const numX = Math.max(1, Math.round(tilesX));
+        const numY = Math.max(1, Math.round(tilesY));
+        const sX = stepSizeX > 0 ? stepSizeX : fovX;
+        const sY = stepSizeY > 0 ? stepSizeY : fovY;
+
+        const snakePositions = buildTileEditorSnakePositions(
+          positionState.x,
+          positionState.y,
+          numX,
+          numY,
+          sX,
+          sY,
+        );
+
+        const scanArea = {
+          areaId: "tile_editor_scan",
+          areaName: "Tile Editor Scan",
+          areaType: "tile_scan",
+          wellId: null,
+          centerPosition: {
+            x: positionState.x + ((numX - 1) * sX) / 2,
+            y: positionState.y + ((numY - 1) * sY) / 2,
+            z: 0,
+          },
+          bounds: {
+            minX: positionState.x,
+            maxX: positionState.x + (numX - 1) * sX,
+            minY: positionState.y,
+            maxY: positionState.y + (numY - 1) * sY,
+          },
+          scanPattern: "snake",
+          positions: snakePositions.map((pos, idx) => ({ ...pos, index: idx })),
+        };
+
+        const pointList = [
+          {
+            id: "tile_editor_scan",
+            name: "Tile Editor Scan",
+            x: scanArea.centerPosition.x,
+            y: scanArea.centerPosition.y,
+            z: 0,
+            iX: 0,
+            iY: 0,
+            wellId: null,
+            areaType: "tile_scan",
+            neighborPointList: snakePositions.map((pos) => ({
+              x: pos.x,
+              y: pos.y,
+              z: 0,
+              iX: pos.iX,
+              iY: pos.iY,
+            })),
+          },
+        ];
+
+        const channelEnabled =
+          experimentState.parameterValue.channelEnabledForExperiment || [];
+        const rawIntensities =
+          experimentState.parameterValue.illuIntensities || [];
+        const filteredIntensities = rawIntensities.map((val, idx) =>
+          channelEnabled[idx] === true ? val : 0
+        );
+
+        const experimentRequest = {
+          name: experimentState.name || "ShitScope_TileEditor",
+          parameterValue: {
+            ...experimentState.parameterValue,
+            illuIntensities: filteredIntensities,
+            resortPointListToSnakeCoordinates: false,
+            is_snakescan: true,
+            overlapWidth: 0,
+            overlapHeight: 0,
+          },
+          scanAreas: [scanArea],
+          scanMetadata: {
+            totalPositions: snakePositions.length,
+            fovX: fovX,
+            fovY: fovY,
+            overlapWidth: 0,
+            overlapHeight: 0,
+            scanPattern: "snake",
+          },
+          pointList,
+        };
+
+        console.log(
+          `[ShitScope TileEditor] ${numX}×${numY} = ${snakePositions.length} tiles, step ${sX}×${sY} µm`
+        );
+
+        await apiExperimentControllerStartWellplateExperiment(experimentRequest);
+        dispatch(experimentStatusSlice.setStatus(Status.RUNNING));
+
+        if (infoPopupRef.current) {
+          infoPopupRef.current.showMessage(
+            `Tile scan started: ${numX}×${numY} = ${snakePositions.length} tiles`
+          );
+        }
+        return;
+      }
+
+      // ── OVERVIEW MODE (existing flow) ────────────────────────────────
       // Step 1: Sync state – raster scan (never snake)
       dispatch(experimentSlice.setIsSnakescan(true  ));
       dispatch(
@@ -250,6 +411,13 @@ const ShitScopeComponent = ({ onOpenFileManager }) => {
     }
   }, [
     dispatch,
+    activeTab,
+    tilesX,
+    tilesY,
+    stepSizeX,
+    stepSizeY,
+    fovX,
+    fovY,
     experimentState,
     objectiveState,
     positionState,
@@ -269,17 +437,6 @@ const ShitScopeComponent = ({ onOpenFileManager }) => {
         console.error("[ShitScope] Stop failed:", err);
       });
   }, [dispatch]);
-
-  // FOV info for display
-  const fovX = objectiveState.fovX || 0;
-  const fovY = objectiveState.fovY || 0;
-  const pixelSize = objectiveState.pixelsize || 0;
-  const tilesX = fovX > 0 ? Math.ceil(SHITSCOPE_SCAN_WIDTH / fovX) : "?";
-  const tilesY = fovY > 0 ? Math.ceil(SHITSCOPE_SCAN_HEIGHT / fovY) : "?";
-  const totalTiles =
-    typeof tilesX === "number" && typeof tilesY === "number"
-      ? tilesX * tilesY
-      : "?";
 
   return (
     <Box sx={{ width: "100%", p: 1 }}>
@@ -316,7 +473,7 @@ const ShitScopeComponent = ({ onOpenFileManager }) => {
           color="info"
         />
         <Chip
-          label={`Tiles: ${tilesX} × ${tilesY} = ${totalTiles}`}
+          label={`Tiles (overview): ${tilesX_computed} × ${tilesY_computed} = ${totalTiles_computed}`}
           variant="outlined"
           size="small"
           color="secondary"
@@ -325,14 +482,107 @@ const ShitScopeComponent = ({ onOpenFileManager }) => {
 
       {/* Main layout: canvas + live view + controls */}
       <Box sx={{ display: "flex", gap: 2 }}>
-        {/* Left panel: Canvas overview always visible, live view always below */}
+        {/* Left panel: tabbed (Overview / Tile Editor) + live view */}
         <Box sx={{ flex: 3, display: "flex", flexDirection: "row", gap: 1 }}>
-          <Box sx={{ flex: 1, minHeight: 220 }}>
-            <Typography variant="caption" color="text.secondary">
-              Overview – click to move stage
-            </Typography>
-            <WellSelectorCanvas ref={canvasRef} />
+          <Box sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
+            {/* Tab bar */}
+            <Tabs
+              value={activeTab}
+              onChange={(_, v) => setActiveTab(v)}
+              sx={{ mb: 1, minHeight: 36 }}
+              variant="fullWidth"
+            >
+              <Tab label="Overview – click to move" sx={{ minHeight: 36, py: 0.5 }} />
+              <Tab label="Tile Editor" sx={{ minHeight: 36, py: 0.5 }} />
+            </Tabs>
+
+            {/* Tab 0: Overview canvas */}
+            {activeTab === 0 && (
+              <Box sx={{ minHeight: 220 }}>
+                <WellSelectorCanvas ref={canvasRef} />
+              </Box>
+            )}
+
+            {/* Tab 1: Tile Editor */}
+            {activeTab === 1 && (
+              <Box sx={{ p: 1 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  Set number of tiles and step size. The scan starts from the
+                  current stage position and runs in a snake pattern.
+                </Typography>
+
+                <Box sx={{ display: "flex", gap: 2, mb: 2 }}>
+                  <TextField
+                    label="Tiles X"
+                    type="number"
+                    size="small"
+                    value={tilesX}
+                    onChange={(e) => setTilesX(Math.max(1, parseInt(e.target.value) || 1))}
+                    inputProps={{ min: 1, step: 1 }}
+                    sx={{ flex: 1 }}
+                    disabled={isRunning}
+                  />
+                  <TextField
+                    label="Tiles Y"
+                    type="number"
+                    size="small"
+                    value={tilesY}
+                    onChange={(e) => setTilesY(Math.max(1, parseInt(e.target.value) || 1))}
+                    inputProps={{ min: 1, step: 1 }}
+                    sx={{ flex: 1 }}
+                    disabled={isRunning}
+                  />
+                </Box>
+
+                <Box sx={{ display: "flex", gap: 2, mb: 2 }}>
+                  <TextField
+                    label="Step X (µm)"
+                    type="number"
+                    size="small"
+                    value={stepSizeX}
+                    onChange={(e) => setStepSizeX(parseFloat(e.target.value) || 0)}
+                    helperText={fovX > 0 ? `Suggested: ${fovX.toFixed(1)} µm (FOV)` : ""}
+                    inputProps={{ min: 1, step: 1 }}
+                    sx={{ flex: 1 }}
+                    disabled={isRunning}
+                  />
+                  <TextField
+                    label="Step Y (µm)"
+                    type="number"
+                    size="small"
+                    value={stepSizeY}
+                    onChange={(e) => setStepSizeY(parseFloat(e.target.value) || 0)}
+                    helperText={fovY > 0 ? `Suggested: ${fovY.toFixed(1)} µm (FOV)` : ""}
+                    inputProps={{ min: 1, step: 1 }}
+                    sx={{ flex: 1 }}
+                    disabled={isRunning}
+                  />
+                </Box>
+
+                <Divider sx={{ my: 1 }} />
+
+                {/* Computed summary */}
+                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                  <Chip
+                    label={`Total tiles: ${tilesX * tilesY}`}
+                    size="small"
+                    color="primary"
+                  />
+                  <Chip
+                    label={`Scan area: ${((tilesX * (stepSizeX || fovX)) / 1000).toFixed(2)} × ${((tilesY * (stepSizeY || fovY)) / 1000).toFixed(2)} mm`}
+                    size="small"
+                    color="secondary"
+                  />
+                  <Chip
+                    label={`Base: (${positionState.x?.toFixed(0) ?? "?"}, ${positionState.y?.toFixed(0) ?? "?"}) µm`}
+                    size="small"
+                    variant="outlined"
+                  />
+                </Box>
+              </Box>
+            )}
           </Box>
+
           <Box sx={{ flex: 1, minHeight: 220 }}>
             <Typography variant="caption" color="text.secondary">
               Live View
@@ -437,23 +687,30 @@ const ShitScopeComponent = ({ onOpenFileManager }) => {
               />
             </Box>
 
-            {/* Progress */}
-            {isRunning && cachedTotalSteps > 0 && (
-              <Box sx={{ mb: 2 }}>
-                <Typography variant="body2" noWrap title={cachedStepName}>
-                  {cachedStepName}
+            {/* Progress – always visible */}
+            <Box sx={{ mb: 2 }}>
+              <Box sx={{ display: "flex", justifyContent: "space-between", mb: 0.5 }}>
+                <Typography variant="body2" color="text.secondary" noWrap title={cachedStepName}>
+                  {isRunning ? cachedStepName || "Running…" : "Idle"}
                 </Typography>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  <Box sx={{ flex: 1 }}>
-                    <LinearProgress variant="determinate" value={progress} />
-                  </Box>
-                  <Typography variant="body2">{progress}%</Typography>
-                </Box>
-                <Typography variant="caption" color="text.secondary">
-                  Step {cachedStepId} / {cachedTotalSteps}
+                <Typography variant="body2" color="text.secondary">
+                  {cachedStepId} / {cachedTotalSteps ?? "–"}
                 </Typography>
               </Box>
-            )}
+              <LinearProgress
+                variant="determinate"
+                value={progress}
+                color={isRunning ? "primary" : "inherit"}
+                sx={{ height: 8, borderRadius: 1 }}
+              />
+              <Typography variant="caption" color="text.secondary">
+                {isRunning
+                  ? `${progress}% complete`
+                  : progress > 0
+                  ? `Last scan: ${progress}% (${cachedStepId}/${cachedTotalSteps})`
+                  : "No scan data yet"}
+              </Typography>
+            </Box>
 
             {/* Open latest scan in file manager */}
             {onOpenFileManager && (

--- a/frontend/src/components/ShitScopeComponent.js
+++ b/frontend/src/components/ShitScopeComponent.js
@@ -229,7 +229,7 @@ const ShitScopeComponent = ({ onOpenFileManager }) => {
         const numY = Math.max(1, Math.round(tilesY));
         const sX = stepSizeX > 0 ? stepSizeX : fovX;
         const sY = stepSizeY > 0 ? stepSizeY : fovY;
-
+        if (sX <= 0 || sY <= 0) throw new Error('Tile Editor requires a positive step size (set Step X/Y or ensure FOV is available).');
         const snakePositions = buildTileEditorSnakePositions(
           positionState.x,
           positionState.y,

--- a/imswitch/imcontrol/controller/controllers/PixelCalibrationController.py
+++ b/imswitch/imcontrol/controller/controllers/PixelCalibrationController.py
@@ -33,7 +33,7 @@ import NanoImagingPack as nip
 
 from imswitch.imcommon.framework import Signal
 from imswitch.imcommon.model import APIExport, initLogger
-from imswitch.imcontrol.controller.controllers.camera_stage_mapping.affine_stage_calibration import compute_affine_matrix, measure_pixel_shift
+from imswitch.imcontrol.controller.controllers.camera_stage_mapping.affine_stage_calibration import compute_affine_matrix, measure_pixel_shift, validate_calibration
 
 from ..basecontrollers import LiveUpdatedController
 
@@ -62,6 +62,10 @@ def _convert_to_native(obj):
     return obj
 
 
+class _CalibrationAborted(Exception):
+    """Raised inside the calibration loop when the user requests a stop."""
+
+
 class PixelCalibrationController(LiveUpdatedController):
     """Controller exposing per-detector affine calibration as a DetectorManager addon."""
 
@@ -82,6 +86,18 @@ class PixelCalibrationController(LiveUpdatedController):
         # Pending (not yet applied) calibrations awaiting frontend approval.
         # Also keyed by the composite key so multiple objectives can be in flight.
         self._pendingCalibration: dict = {}
+
+        # Cooperative abort for the automatic calibration loop + pollable progress
+        # so the frontend can show a progress bar and a working Stop button.
+        self._calibrationAbort = threading.Event()
+        self._calibrationProgress: dict = {
+            "running": False,
+            "step": 0,
+            "total": 0,
+            "message": "",
+            "detectorName": None,
+            "objectiveId": None,
+        }
 
         # Currently selected objective (string key).
         self.currentObjective = self._getCurrentObjectiveId()
@@ -208,6 +224,63 @@ class PixelCalibrationController(LiveUpdatedController):
             except Exception as exc:
                 self._logger.warning(f"[{detector_name}] setPixelSizeUm failed: {exc}")
 
+    def _resetDetectorFlip(self, detector_name: str):
+        """Force a detector's image flip to (False, False).
+
+        Calibration must be *measured* on the raw, unflipped sensor. If a flip
+        from a previous calibration (or a manual toggle) is still active, the
+        measured pixel-shift direction is already mirrored, and the freshly
+        computed calibration would compensate a second time — inverting the
+        axes. Resetting first makes the computed flip an absolute property of
+        the camera/stage geometry rather than a delta on top of the old one.
+        """
+        try:
+            detector = self._master.detectorsManager[detector_name]
+        except Exception:
+            self._logger.warning(f"Detector '{detector_name}' not found - cannot reset flip")
+            return
+        if hasattr(detector, "setFlipImage"):
+            try:
+                detector.setFlipImage(False, False)
+                self._logger.info(f"[{detector_name}] flip reset to (False, False) for calibration")
+            except Exception as exc:
+                self._logger.warning(f"[{detector_name}] flip reset failed: {exc}")
+
+    def _restoreAppliedFlip(self, detector_name: str):
+        """Re-apply the flip/pixel-size of the detector's *currently active* calibration.
+
+        Used after an automatic run measured on the reset (unflipped) sensor, so
+        the live view returns to its prior state until the user applies the new
+        pending calibration. Falls back to leaving the sensor unflipped when no
+        calibration is stored for the active objective.
+        """
+        calib = self.affineCalibrations.get(
+            self._makeKey(detector_name, self.currentObjective)
+        ) or self.affineCalibrations.get(detector_name)
+        if calib is not None:
+            self._applyCalibrationToDetector(detector_name, calib)
+        else:
+            self._resetDetectorFlip(detector_name)
+
+    @APIExport(requestType="POST")
+    def resetDetectorFlip(self, detectorName: str = None):
+        """Reset a detector's image flip to off.
+
+        Called by the manual calibration workflow before the user marks feature
+        points, so the points are captured on the raw (unflipped) sensor and the
+        computed flip is absolute — see ``_resetDetectorFlip``.
+        """
+        if detectorName is None or detectorName == "":
+            detectorName = self._defaultDetectorName()
+        if detectorName not in self._master.detectorsManager.getAllDeviceNames():
+            return {"success": False, "error": f"Unknown detector '{detectorName}'"}
+        self._resetDetectorFlip(detectorName)
+        return {
+            "success": True,
+            "detectorName": detectorName,
+            "message": "Image flip reset to off for calibration.",
+        }
+
     # ------------------------------------------------------------------ #
     # Lookup helpers (used by other controllers)                          #
     # ------------------------------------------------------------------ #
@@ -303,14 +376,33 @@ class PixelCalibrationController(LiveUpdatedController):
                 "error": f"Unknown detector '{detectorName}'",
             }
 
-        if not self._validateCameraIntensity(detectorName):
+        if self._calibrationProgress.get("running"):
+            return {
+                "success": False,
+                "error": "A calibration is already running. Stop it first.",
+            }
+
+        intensity_ok, intensity_reason = self._validateCameraIntensity(detectorName)
+        if not intensity_ok:
             return {
                 "success": False,
                 "error": (
-                    "Camera intensity out of range (saturated or too dark). "
+                    f"Camera intensity problem: {intensity_reason}. "
                     "Adjust exposure or lighting before calibration."
                 ),
             }
+
+        # Arm the abort flag and progress state before the worker starts.
+        self._calibrationAbort.clear()
+        self._pendingCalibration.pop(self._makeKey(detectorName, objectiveId), None)
+        self._calibrationProgress = {
+            "running": True,
+            "step": 0,
+            "total": 0,
+            "message": "Starting…",
+            "detectorName": detectorName,
+            "objectiveId": objectiveId,
+        }
 
         thread = threading.Thread(
             target=self._calibrateStageAffineInThread,
@@ -323,8 +415,23 @@ class PixelCalibrationController(LiveUpdatedController):
             "pending": False,
             "detectorName": detectorName,
             "objectiveId": objectiveId,
-            "message": "Calibration started in background thread. Poll getPendingCalibration for results.",
+            "message": "Calibration started in background thread. Poll getCalibrationProgress / getPendingCalibration for results.",
         }
+
+    @APIExport(requestType="POST")
+    def stopPixelCalibration(self):
+        """Request the running automatic calibration to abort at the next step."""
+        if not self._calibrationProgress.get("running"):
+            return {"success": False, "message": "No calibration is running."}
+        self._calibrationAbort.set()
+        self._calibrationProgress["message"] = "Stopping…"
+        self._logger.info("Stop requested for automatic calibration")
+        return {"success": True, "message": "Stop requested; calibration will abort shortly."}
+
+    @APIExport()
+    def getCalibrationProgress(self):
+        """Return the live progress of the automatic calibration for polling."""
+        return _convert_to_native({"success": True, **self._calibrationProgress})
 
     def _calibrateStageAffineInThread(
         self,
@@ -339,6 +446,8 @@ class PixelCalibrationController(LiveUpdatedController):
     ):
         key = self._makeKey(detectorName, objectiveId)
         try:
+            # Measure on the raw, unflipped sensor so the computed flip is absolute.
+            self._resetDetectorFlip(detectorName)
             helper = PixelCalibrationClass(self, detectorName=detectorName)
             result = helper.calibrate_affine(
                 backlash_um=backlashUm,
@@ -358,10 +467,16 @@ class PixelCalibrationController(LiveUpdatedController):
                 "detector_name": detectorName,
                 "objective_id": objectiveId,
             }
+            self._calibrationProgress["message"] = "Complete – review and apply."
             self._logger.info(
                 f"Calibration pending approval for '{detectorName}' @ objective '{objectiveId}'"
             )
             return self._pendingCalibration[key]
+        except _CalibrationAborted:
+            self._logger.info(f"Calibration aborted by user for '{key}'")
+            self._pendingCalibration.pop(key, None)
+            self._calibrationProgress["message"] = "Aborted by user."
+            return None
         except Exception as exc:
             self._logger.error(
                 f"Calibration thread failed for '{key}': {exc}", exc_info=True
@@ -372,7 +487,14 @@ class PixelCalibrationController(LiveUpdatedController):
                 "objective_id": objectiveId,
                 "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
             }
+            self._calibrationProgress["message"] = f"Failed: {exc}"
             return None
+        finally:
+            self._calibrationProgress["running"] = False
+            # The new flip is only applied once the user accepts the pending
+            # result; until then, restore the previously-active calibration so
+            # the live view does not stay stuck on the raw (unflipped) sensor.
+            self._restoreAppliedFlip(detectorName)
 
     @APIExport()
     def getPendingCalibration(self, detectorName: str = None, objectiveId: str = None):
@@ -871,35 +993,55 @@ class PixelCalibrationController(LiveUpdatedController):
     # Internal helpers                                                    #
     # ------------------------------------------------------------------ #
 
-    def _validateCameraIntensity(self, detectorName: str) -> bool:
-        """Reject calibrations when the detector frame is saturated or too dark."""
+    def _validateCameraIntensity(self, detectorName: str):
+        """Check that a detector frame is usable for calibration.
+
+        Returns ``(ok, reason)``. ``ok`` is False when the frame is too dark
+        *or* too saturated (clipped) — both starve phase correlation of the
+        texture it needs to find a reliable shift. RGB frames are reduced to
+        grayscale (matching the calibration grab) but thresholds are keyed off
+        the original dtype.
+        """
         try:
             detector = self._master.detectorsManager[detectorName]
             if not hasattr(detector, "getLatestFrame"):
-                return True
+                return True, "ok"
             frame = detector.getLatestFrame()
             if frame is None:
-                return True
+                return True, "ok"
+            orig_dtype = frame.dtype
+            if frame.ndim > 2:  # RGB -> grayscale, matching the calibration grab
+                frame = np.mean(frame, axis=2)
             max_val = float(np.max(frame))
             mean_val = float(np.mean(frame))
-            if frame.dtype == np.uint8:
+            if orig_dtype == np.uint8:
                 min_threshold = 10
-            elif frame.dtype == np.uint16:
+                sat_level = 255.0
+            elif orig_dtype == np.uint16:
                 min_threshold = 50 if max_val < 4096 else 500
+                sat_level = 4095.0 if max_val < 4096 else 65535.0
             else:
                 min_threshold = 0.02
+                sat_level = max(max_val, 1.0)
             if mean_val <= min_threshold:
                 self._logger.warning(
                     f"[{detectorName}] frame too dark (mean={mean_val:.1f}, threshold={min_threshold})"
                 )
-                return False
+                return False, f"frame too dark (mean intensity {mean_val:.1f})"
+            sat_fraction = float(np.mean(frame >= 0.98 * sat_level))
+            if sat_fraction > 0.20:
+                self._logger.warning(
+                    f"[{detectorName}] frame saturated ({sat_fraction * 100:.0f}% of pixels clipped)"
+                )
+                return False, f"frame saturated ({sat_fraction * 100:.0f}% of pixels clipped)"
             self._logger.info(
-                f"[{detectorName}] intensity OK: mean={mean_val:.1f}, max={max_val:.1f}"
+                f"[{detectorName}] intensity OK: mean={mean_val:.1f}, max={max_val:.1f}, "
+                f"saturated={sat_fraction * 100:.1f}%"
             )
-            return True
+            return True, "ok"
         except Exception as exc:
             self._logger.warning(f"Intensity validation failed: {exc}")
-            return True
+            return True, "ok"
 
 
 class PixelCalibrationClass:
@@ -914,8 +1056,32 @@ class PixelCalibrationClass:
     def _detector(self):
         return self._parent._master.detectorsManager[self._detectorName]
 
+    def _grab_timeout_s(self, frameSync: int) -> float:
+        """Frame-grab timeout that scales with exposure.
+
+        The grab waits for the frame counter to advance by ``frameSync``. On a
+        slow camera (e.g. RGB / long exposure) a fixed 1 s timeout fires before
+        a genuinely new frame arrives, so the loop returns a *stale* frame —
+        identical to the reference — giving ~0 displacement and an absurd pixel
+        size. Scaling the timeout with exposure keeps the grab honest.
+        """
+        exposure_s = None
+        try:
+            params = getattr(self._detector, "parameters", {}) or {}
+            for k in ("exposure", "ExposureTime", "exposure_time", "Exposure"):
+                if k in params and params[k] is not None:
+                    val = float(getattr(params[k], "value", params[k]))
+                    # Heuristic: values over 30 are almost certainly milliseconds.
+                    exposure_s = val / 1000.0 if val > 30 else val
+                    break
+        except Exception:
+            exposure_s = None
+        if not exposure_s or exposure_s <= 0:
+            return 2.0
+        return max(2.0, (frameSync + 2) * exposure_s + 1.0)
+
     def _grab_image(self, crop_size: int = 1024, frameSync: int = 3, returnFrameNumber: bool = False):
-        timeout_s = 1.0  # TODO: scale with exposure
+        timeout_s = self._grab_timeout_s(frameSync)
         t0 = time.time()
         last_fn = -1
         cur_fn = None
@@ -1011,8 +1177,15 @@ class PixelCalibrationClass:
         pixel_shifts = []
         stage_shifts = []
         correlations = []
+        self._parent._calibrationProgress["total"] = len(offsets)
         try:
             for idx, (dx, dy) in enumerate(offsets):
+                # Cooperative abort point (Stop button) between steps.
+                if self._parent._calibrationAbort.is_set():
+                    raise _CalibrationAborted()
+                self._parent._calibrationProgress.update(
+                    {"step": idx, "message": f"Measuring step {idx + 1}/{len(offsets)}…"}
+                )
                 target = start_position + np.array([dx, dy, 0])
                 self._move_stage(target)
                 time.sleep(settle_time)
@@ -1021,6 +1194,7 @@ class PixelCalibrationClass:
                 pixel_shifts.append(shift)
                 stage_shifts.append([dx, dy])
                 correlations.append(corr)
+                self._parent._calibrationProgress["step"] = idx + 1
                 self._parent._logger.debug(
                     f"Step {idx + 1}/{len(offsets)}: stage=({dx:.1f},{dy:.1f}) "
                     f"px=({shift[0]:.2f},{shift[1]:.2f}) corr={corr:.3f}"
@@ -1041,6 +1215,29 @@ class PixelCalibrationClass:
         affine_matrix, inlier_mask, metrics = compute_affine_matrix(pixel_shifts, stage_shifts)
         metrics["mean_correlation"] = float(np.mean(correlations))
         metrics["min_correlation"] = float(np.min(correlations))
+
+        # Degenerate-measurement guard: if commanded moves produced essentially no
+        # image displacement, the frames were stale/identical (slow camera, no
+        # texture) and the pixel size would be meaningless — fail loudly instead
+        # of storing an "arbitrary" calibration.
+        nonzero = np.linalg.norm(stage_shifts, axis=1) > 1e-6
+        if np.any(nonzero):
+            measured_disp = np.linalg.norm(pixel_shifts[nonzero], axis=1)
+            if float(np.max(measured_disp)) < 1.0:
+                raise RuntimeError(
+                    "Calibration failed: commanded stage moves produced < 1 px image "
+                    "displacement (stale frames or no visible texture). Increase exposure, "
+                    "add contrast/texture to the sample, or increase the step size."
+                )
+
+        # Attach a quality verdict so the frontend can warn before applying.
+        try:
+            ok, msg = validate_calibration(np.array(affine_matrix), metrics, self._parent._logger)
+            metrics["validation_ok"] = bool(ok)
+            metrics["validation_message"] = str(msg)
+        except Exception as exc:  # pragma: no cover - validation must never crash a run
+            metrics["validation_ok"] = None
+            metrics["validation_message"] = f"validation skipped: {exc}"
 
         self._parent._logger.info(
             f"Calibration done: quality={metrics.get('quality', 'n/a')} "

--- a/imswitch/imcontrol/model/managers/detectors/GXPIPYManager.py
+++ b/imswitch/imcontrol/model/managers/detectors/GXPIPYManager.py
@@ -77,8 +77,9 @@ class GXPIPYManager(DetectorManager):
                                     editable=True),
             'flat_fielding': DetectorBooleanParameter(group='Misc', value=True, editable=True),
             'binning': DetectorNumberParameter(group="Misc", value=1, valueUnits="arb.u.", editable=True),
-            'flipX': DetectorBooleanParameter(group="Misc", value=self.flipX, editable=True),
-            'flipY': DetectorBooleanParameter(group="Misc", value=self.flipY, editable=True),
+            # Flip is owned by PixelCalibration (set via setFlipImage), not the user.
+            'flipX': DetectorBooleanParameter(group="Misc", value=self.flipX, editable=False),
+            'flipY': DetectorBooleanParameter(group="Misc", value=self.flipY, editable=False),
             'trigger_source': DetectorListParameter(group='Acquisition mode',
                             value='Continuous',
                             options=['Continuous',

--- a/imswitch/imcontrol/model/managers/detectors/VirtualCameraManager.py
+++ b/imswitch/imcontrol/model/managers/detectors/VirtualCameraManager.py
@@ -66,8 +66,9 @@ class VirtualCameraManager(DetectorManager):
                             editable=True),
             'Camera pixel size': DetectorNumberParameter(group='Miscellaneous', value=pixelSize,
                                                 valueUnits='µm', editable=True),
-            'flipX': DetectorBooleanParameter(group='Misc', value=flipX, editable=True),
-            'flipY': DetectorBooleanParameter(group='Misc', value=flipY, editable=True)
+            # Flip is owned by PixelCalibration (set via setFlipImage), not the user.
+            'flipX': DetectorBooleanParameter(group='Misc', value=flipX, editable=False),
+            'flipY': DetectorBooleanParameter(group='Misc', value=flipY, editable=False)
             }
 
         # reading parameters from disk and write them to camrea


### PR DESCRIPTION
Introduce new pixel-calibration features and UX improvements across frontend and backend. Add three backend API clients (getCalibrationProgress, resetDetectorFlip, stopPixelCalibration) and update PixelCalibrationController/driver managers to support progress reporting, stopping and flip resets. LiveViewControlWrapper gains an enableZoomPan prop so the viewer can bypass the zoom/pan layer for precise single-click workflows.

ManualPixelCalibrationTab: disable zoom/pan for marking, add auto-move stage toggle, reset detector flip before marking, preserve calibration flip when editing pixel size, sticky live view layout, and other workflow refinements. PixelCalibrationTab: implement start/stop flow, poll calibration progress and pending results, show progress bar and validation status, keep measured flip semantics, and sticky live view. Add a new VerifyCalibrationTab component (and register its tab) to visually sanity-check stored calibrations by marking a feature and nudging the stage with predicted overlay guidance. Also add explanatory info to StageOffsetCalibrationTab and annotate ObjectiveController buttons with tooltips and an illustrative diagram.